### PR TITLE
Fix class instances always being callable

### DIFF
--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -3,6 +3,12 @@ from typing import Any
 from unittest import mock
 
 
+class _MISSING:
+    """
+    Class to indicate a missing value
+    """
+
+
 class _MegaMockMixin:
     def __init__(
         self,
@@ -20,8 +26,9 @@ class _MegaMockMixin:
     ) -> None:
         self._megamock_spec = spec
 
-        # must be last
-        self.__wrapped = _wraps_mock
+        # !important!
+        # once __wrapped is set, future assignments will be on the wrapped object
+        # it MUST be last
         if _wraps_mock is None:
             if spec is not None:
                 autospeced_legacy_mock = mock.create_autospec(
@@ -30,6 +37,29 @@ class _MegaMockMixin:
                 self.__wrapped = autospeced_legacy_mock
             else:
                 super().__init__(**kwargs)
+        else:
+            self._mock_return_value_ = _wraps_mock.return_value
+            self.__wrapped = _wraps_mock
+
+    @property
+    def _mock_return_value(self) -> Any:
+        if self.__dict__.get("_MegaMockMixin__wrapped"):
+            if (
+                val := self.__dict__.get("_mock_return_value_cache", _MISSING)
+            ) == _MISSING:
+                if isinstance(
+                    self._mock_return_value_,
+                    mock.NonCallableMagicMock | mock.NonCallableMock,
+                ):
+                    val = self._mock_return_value_cache = MegaMock.from_legacy_mock(
+                        self._mock_return_value_, None
+                    )
+                else:
+                    val = self._mock_return_value_cache = self._mock_return_value_
+            return val
+        return self.__dict__.get(
+            "_mock_return_value", self.__class__._mock_return_value  # type: ignore
+        )
 
     def _get_child_mock(self, /, **kw) -> MegaMock:
         return MegaMock(**kw)
@@ -37,7 +67,9 @@ class _MegaMockMixin:
     def __getattr__(self, key) -> Any:
         if (wrapped := self.__dict__.get("_MegaMockMixin__wrapped")) is not None:
             result = getattr(wrapped, key)
-            if isinstance(result, mock.NonCallableMock | mock.NonCallableMagicMock):
+            if not isinstance(result, _MegaMockMixin) and isinstance(
+                result, mock.NonCallableMock | mock.NonCallableMagicMock
+            ):
                 mega_result = MegaMock.from_legacy_mock(
                     result, getattr(self._megamock_spec, key, None)
                 )

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -58,7 +58,7 @@ class _MegaMockMixin:
                     val = self._mock_return_value_cache = self._mock_return_value_
             return val
         return self.__dict__.get(
-            "_mock_return_value", self.__class__._mock_return_value  # type: ignore
+            "_mock_return_value", self.__class__._mock_return_value
         )
 
     def _get_child_mock(self, /, **kw) -> MegaMock:

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -117,9 +117,7 @@ class MegaPatch:
                     autospeced.return_value = return_value
                 new = autospeced
             else:
-                new = MegaMock.from_legacy_mock(
-                    mock.create_autospec(thing, spec_set=spec_set), spec=thing
-                )
+                new = MegaMock.from_legacy_mock(autospeced, spec=thing)
             return_value = new.return_value
         else:
             if return_value is _MISSING:

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -11,6 +11,9 @@ class TestMegaMock:
     def test_allows_no_args(self) -> None:
         MegaMock()
 
+    def test_return_value_when_no_args(self) -> None:
+        assert isinstance(MegaMock()(), MegaMock)
+
     class TestMockingAClass:
         def test_classes_default_to_instance(self) -> None:
             mock_instance: SomeClass = MegaMock(SomeClass)
@@ -65,6 +68,8 @@ class TestMegaMock:
 
             assert isinstance(mega_mock.b, MegaMock)
             assert isinstance(mega_mock.c, NonCallableMegaMock)
+
+            assert isinstance(mega_mock.return_value, NonCallableMegaMock)
 
         def test_when_regular_mock(self) -> None:
 

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -18,6 +18,11 @@ class TestMegaPatchPatching:
         patch.new_value.z = "a"
 
         assert Foo.z == "a"
+        Foo("s")  # should work
+
+        # sanity check, instance should NOT work because it doesn't support calling
+        with pytest.raises(TypeError):
+            Foo("s")()  # type: ignore
 
     def test_patch_class_instance(self) -> None:
         patch = MegaPatch.it(Foo)


### PR DESCRIPTION
`Foo()()` was not erroring, when it should be (class is not callable)