### PR TITLE
#4 Add `spy` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,32 @@ from my_module import MyClass
 mock_class = MegaMock(MyClass, instance=False)
 ```
 
+Spying an object, then checking about it:
+
+```python
+from my_module import MyClass
+
+my_thing = MyClass()
+spied_class = MegaMock(spy=my_thing)
+
+# ... do stuff with spied_class...
+
+spied_class.some_method.call_args_list  # same as wraps
+
+# check whether a value was accessed
+# if things aren't as expected, you can pull up the debugger and see the stack traces
+assert len(spied_class.megamock_spied_access["some_attribute"]) == 1
+
+spy_access_list = spied_class.megamock_spied_access["some_attribute"]
+spy_access: SpyAccess = spy_access_list[0]
+spy_access.attr_value  # shallow copy of what was returned
+spy_access.stacktrace  # where the access happened
+spy_access.time  # when it happened (from time.time())
+spy_access.format_stacktrace()  # return a list of strings for the stacktrace
+spy_access.print_stacktrace()  # display the stacktrace to the console
+```
+
+
 Patching a class:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ spy_access: SpyAccess = spy_access_list[0]
 spy_access.attr_value  # shallow copy of what was returned
 spy_access.stacktrace  # where the access happened
 spy_access.time  # when it happened (from time.time())
+spy_access.top_of_stacktrace  # a shorthand property intended to be used when debugging in the IDE
 spy_access.format_stacktrace()  # return a list of strings for the stacktrace
 spy_access.print_stacktrace()  # display the stacktrace to the console
 ```

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from collections import defaultdict
+import copy
 import time
 import traceback
 from typing import Any
@@ -12,8 +13,22 @@ class _MISSING:
     """
 
 
-class AttributeAssignment:
-    def __init__(self, attr_name: str, attr_value: Any, stacktrace) -> None:
+class AttributeTrackingBase:
+    stacktrace: list[traceback.FrameSummary]
+
+    def format_stacktrace(self, max_depth=100) -> list[str]:
+        # for lists, the first frame is the most recent
+        return traceback.format_list(self.stacktrace[:max_depth])
+
+    def print_stacktrace(self, max_depth=100) -> None:
+        # when printing stacktraces, display the most recent frame last
+        traceback.print_list(self.stacktrace[:-max_depth:-1])
+
+
+class AttributeAssignment(AttributeTrackingBase):
+    def __init__(
+        self, attr_name: str, attr_value: Any, stacktrace: list[traceback.FrameSummary]
+    ) -> None:
         self.attr_name = attr_name
         self.attr_value = attr_value
         self.stacktrace = stacktrace  # 0 is most recent frame, not oldest frame
@@ -25,6 +40,25 @@ class AttributeAssignment:
     ) -> AttributeAssignment:
         stacktrace = traceback.extract_stack()[-starting_depth::-1]
         return AttributeAssignment(attr_name, attr_value, stacktrace)
+
+
+class SpyAccess(AttributeTrackingBase):
+    def __init__(
+        self, attr_name: str, attr_value: Any, stacktrace: list[traceback.FrameSummary]
+    ) -> None:
+        self.attr_name = attr_name
+        self.attr_value = copy.copy(
+            attr_value  # just doing shallow copy, may need to revisit in future
+        )
+        self.stacktrace = stacktrace  # 0 is most recent frame, not oldest frame
+        self.time = time.time()
+
+    @staticmethod
+    def for_current_stack(
+        attr_name: str, attr_value: Any, starting_depth=3
+    ) -> SpyAccess:
+        stacktrace = traceback.extract_stack()[-starting_depth::-1]
+        return SpyAccess(attr_name, attr_value, stacktrace)
 
 
 class _MegaMockMixin:
@@ -39,12 +73,21 @@ class _MegaMockMixin:
             | None
         ) = None,
         wraps: Any = None,
+        spy: Any = None,
         spec_set=True,
         instance=True,
         # warning: kwargs to MagicMock may not work correctly! Use at your own risk!
         **kwargs,
     ) -> None:
-        self.wraps = wraps
+        self.megamock_spied_access: defaultdict[str, list[SpyAccess]] = defaultdict(
+            list
+        )
+        # self.megamock_spy = spy
+        if wraps and spy:
+            # if spy is used, then the spied value is also wrapped
+            raise Exception("Cannot both wrap and spy")
+
+        self.megamock_wraps = wraps = wraps or spy
         self.megamock_spec = spec
         self.megamock_attr_assignments: defaultdict[
             str, list[AttributeAssignment]
@@ -52,8 +95,10 @@ class _MegaMockMixin:
         if wraps and not _wraps_mock:
             _wraps_mock = mock.MagicMock(wraps=wraps)
 
+        self.megamock_spy = spy
         # !important!
         # once __wrapped is set, future assignments will be on the wrapped object
+        # __wrapped becomes "_MegaMockMixin__wrapped"
         # it MUST be last
         if _wraps_mock is None:
             if spec is not None:
@@ -83,7 +128,7 @@ class _MegaMockMixin:
                     mock.NonCallableMagicMock | mock.NonCallableMock,
                 ):
                     val = self._mock_return_value_cache = MegaMock.from_legacy_mock(
-                        self._mock_return_value_, None, self.wraps
+                        self._mock_return_value_, None, self.megamock_wraps
                     )
                 else:
                     val = self._mock_return_value_cache = self._mock_return_value_
@@ -96,13 +141,22 @@ class _MegaMockMixin:
         return MegaMock(**kw)
 
     def __getattr__(self, key) -> Any:
+        if key not in ("megamock_spy", "megamock_spied_access") and self.megamock_spy:
+            result = getattr(self.megamock_spy, key)
+            # if result is callable let wrapped handle it so that it's a mock object
+            if not callable(result):
+                self.megamock_spied_access[key].append(
+                    SpyAccess.for_current_stack(key, result)
+                )
+                return result
+
         if (wrapped := self.__dict__.get("_MegaMockMixin__wrapped")) is not None:
             result = getattr(wrapped, key)
             if not isinstance(result, _MegaMockMixin) and isinstance(
                 result, mock.NonCallableMock | mock.NonCallableMagicMock
             ):
                 mega_result = MegaMock.from_legacy_mock(
-                    result, getattr(self.megamock_spec, key, None), self.wraps
+                    result, getattr(self.megamock_spec, key, None), self.megamock_wraps
                 )
                 setattr(wrapped, key, mega_result)
                 return mega_result
@@ -110,7 +164,9 @@ class _MegaMockMixin:
         raise AttributeError(key)
 
     def __setattr__(self, key, value) -> None:
-        if (wrapped := self.__dict__.get("_MegaMockMixin__wrapped")) is not None:
+        if key != "_MegaMockMixin__wrapped" and self.__dict__.get("megamock_spy"):
+            setattr(self.megamock_spy, key, value)
+        elif (wrapped := self.__dict__.get("_MegaMockMixin__wrapped")) is not None:
             try:
                 setattr(wrapped, key, value)
             except AttributeError:

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -21,7 +21,9 @@ class AttributeTrackingBase(metaclass=ABCMeta):
     @property
     def top_of_stacktrace(self) -> list[str]:
         """
-        Convenience property for quickly viewing the stacktrace in an IDE debugger
+        Convenience property for quickly viewing the stacktrace in an IDE debugger.
+
+        This displays the folder / file and then the rest of the stacktrace
         """
         ret = []
         for x in self.format_stacktrace(5):

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from abc import ABCMeta
 from collections import defaultdict
 import copy
+import re
 import time
 import traceback
 from typing import Any
@@ -13,8 +15,25 @@ class _MISSING:
     """
 
 
-class AttributeTrackingBase:
+class AttributeTrackingBase(metaclass=ABCMeta):
     stacktrace: list[traceback.FrameSummary]
+
+    @property
+    def top_of_stacktrace(self) -> list[str]:
+        """
+        Convenience property for quickly viewing the stacktrace in an IDE debugger
+        """
+        ret = []
+        for x in self.format_stacktrace(5):
+            if rslt := re.search(
+                r"[^/\\]+[/\\][\w\.]+\", line \d+,.*", x, re.MULTILINE | re.DOTALL
+            ):
+                lines = rslt.group(0).splitlines()
+                lines[0] = "..." + lines[0]
+                ret.extend([line for line in lines if line])
+            else:
+                ret.append(x)
+        return ret
 
     def format_stacktrace(self, max_depth=100) -> list[str]:
         # for lists, the first frame is the most recent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "megamock"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 description = "Mega mocking capabilities - stop using dot-notated paths!"
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -4,6 +4,7 @@ import pytest
 
 from megamock import MegaMock
 from megamock.megamocks import AttributeTrackingBase, NonCallableMegaMock
+from megamock.megapatches import MegaPatch
 from tests.conftest import SomeClass
 from tests.simple_app.bar import Bar
 from tests.simple_app.foo import Foo
@@ -23,6 +24,15 @@ class TestAttributeTrackingBase:
     def test_top_of_stacktrace_shortens_path(self) -> None:
         obj = TestAttributeTrackingBase.Sample()
         assert obj.top_of_stacktrace[0].startswith("...")
+
+    def test_top_of_stacktrace_root_folder(self) -> None:
+        obj = TestAttributeTrackingBase.Sample()
+
+        MegaPatch.it(
+            AttributeTrackingBase.format_stacktrace,
+            return_value=['"file_in_root.py", line 1,  something something'],
+        )
+        assert obj.top_of_stacktrace[0].startswith('"file_in_root.py')
 
 
 class TestMegaMock:

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -3,10 +3,26 @@ from unittest import mock
 import pytest
 
 from megamock import MegaMock
-from megamock.megamocks import NonCallableMegaMock
+from megamock.megamocks import AttributeTrackingBase, NonCallableMegaMock
 from tests.conftest import SomeClass
 from tests.simple_app.bar import Bar
 from tests.simple_app.foo import Foo
+
+
+class TestAttributeTrackingBase:
+    class Sample(AttributeTrackingBase):
+        def __init__(self) -> None:
+            import traceback
+
+            self.stacktrace = traceback.extract_stack()[::-1]
+
+    def test_top_of_stacktrace_breaks_up_lines(self) -> None:
+        obj = TestAttributeTrackingBase.Sample()
+        assert len(obj.top_of_stacktrace) == 10
+
+    def test_top_of_stacktrace_shortens_path(self) -> None:
+        obj = TestAttributeTrackingBase.Sample()
+        assert obj.top_of_stacktrace[0].startswith("...")
 
 
 class TestMegaMock:

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -1,4 +1,3 @@
-from typing import cast
 from unittest import mock
 
 import pytest

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest import mock
 
 import pytest
@@ -174,3 +175,39 @@ class TestMegaMock:
             mega_mock = MegaMock(wraps=obj)
 
             assert isinstance(mega_mock.s, MegaMock)
+
+    class TestSpy:
+        def test_equivalent_to_wraps_for_methods(self) -> None:
+            obj = Foo("s")
+            mega_mock = MegaMock(spy=obj)
+
+            assert mega_mock.some_method() == "value"
+            assert len(mega_mock.some_method.call_args_list) == 1
+
+        def test_supports_properties(self) -> None:
+            obj = Foo("s")
+            mega_mock = MegaMock(spy=obj)
+
+            mega_mock._s = "str"
+            assert mega_mock.s == "str"
+
+        def test_supports_attributes(self) -> None:
+            obj = Foo("s")
+            mega_mock = MegaMock(spy=obj)
+
+            assert mega_mock._s == "s"
+
+        def test_spies_on_attribute_access(self) -> None:
+            obj = Foo("s")
+            mega_mock = MegaMock(spy=obj)
+
+            mega_mock.z
+            mega_mock.moo
+            mega_mock.helpful_manager
+
+            assert len(mega_mock.megamock_spied_access) == 3
+            assert (
+                mega_mock.megamock_spied_access["z"][0]
+                .stacktrace[0]
+                .filename.endswith("test_megamocks.py")
+            )


### PR DESCRIPTION
This adds the ability to spy an object. You can track what attributes are accessed and also look at method calls, similar to `wraps`. This differentiates from `wraps` in that:

- properties use their logic
- attributes use their values

Likewise, assignments go to the spied object