### PR TITLE
#7 Add async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .venv
 *.pyc
 .dmypy.json
+dist

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ MegaPatch.it(
 
 # Behavior differences from `mock`
 - Using `MegaMock` is like using the `mock.create_autospec()` function
+  - This means a `MegaMock` object may support `async` functionality if the mocked object is async.
 - Using `MegaPatch` is like setting `autospec=True`
 - Mocking a class by default returns an instance of the class instead of a mocked type. This is like setting `instance=True`
 

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -160,9 +160,6 @@ class _MegaMockMixin:
     def _get_child_mock(self, /, **kw) -> MegaMock:
         return MegaMock(**kw)
 
-    def __getattribute__(self, name: str) -> Any:
-        return super().__getattribute__(name)
-
     def __getattr__(self, key) -> Any:
         if key not in ("megamock_spy", "megamock_spied_access") and self.megamock_spy:
             result = getattr(self.megamock_spy, key)

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -103,7 +103,6 @@ class _MegaMockMixin:
         self.megamock_spied_access: defaultdict[str, list[SpyAccess]] = defaultdict(
             list
         )
-        # self.megamock_spy = spy
         if wraps and spy:
             # if spy is used, then the spied value is also wrapped
             raise Exception("Cannot both wrap and spy")
@@ -251,4 +250,5 @@ class NonCallableMegaMock(_MegaMockMixin, mock.NonCallableMagicMock):
 
 
 class AsyncMegaMock(_MegaMockMixin, mock.AsyncMock):
-    pass
+    def _get_child_mock(self, /, **kw) -> AsyncMegaMock:
+        return AsyncMegaMock(**kw)

--- a/poetry.lock
+++ b/poetry.lock
@@ -115,14 +115,14 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.1.0"
+version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.1.0-py3-none-any.whl", hash = "sha256:327cbda3da756e2de031a3107b81ab7b3770a602c4d16ca618298c526f4bec1e"},
-    {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
+    {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
+    {file = "exceptiongroup-1.1.1.tar.gz", hash = "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"},
 ]
 
 [package.extras]
@@ -261,26 +261,26 @@ files = [
 
 [[package]]
 name = "pathspec"
-version = "0.11.0"
+version = "0.11.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
-    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
+    {file = "pathspec-0.11.1-py3-none-any.whl", hash = "sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293"},
+    {file = "pathspec-0.11.1.tar.gz", hash = "sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687"},
 ]
 
 [[package]]
 name = "platformdirs"
-version = "3.0.0"
+version = "3.1.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.0.0-py3-none-any.whl", hash = "sha256:b1d5eb14f221506f50d6604a561f4c5786d9e80355219694a1b244bcd96f4567"},
-    {file = "platformdirs-3.0.0.tar.gz", hash = "sha256:8a1228abb1ef82d788f74139988b137e78692984ec7b08eaa6c65f1723af28f9"},
+    {file = "platformdirs-3.1.1-py3-none-any.whl", hash = "sha256:e5986afb596e4bb5bde29a79ac9061aa955b94fca2399b7aaac4090860920dd8"},
+    {file = "platformdirs-3.1.1.tar.gz", hash = "sha256:024996549ee88ec1a9aa99ff7f8fc819bb59e2c3477b410d90a16d32d6e707aa"},
 ]
 
 [package.extras]
@@ -329,14 +329,14 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "7.2.1"
+version = "7.2.2"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
-    {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
+    {file = "pytest-7.2.2-py3-none-any.whl", hash = "sha256:130328f552dcfac0b1cec75c12e3f005619dc5f874f0a06e8ff7263f0ee6225e"},
+    {file = "pytest-7.2.2.tar.gz", hash = "sha256:c99ab0c73aceb050f68929bc93af19ab6db0558791c6a0715723abe9d0ade9d4"},
 ]
 
 [package.dependencies]
@@ -350,6 +350,25 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.20.3"
+description = "Pytest support for asyncio"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.20.3.tar.gz", hash = "sha256:83cbf01169ce3e8eb71c6c278ccb0574d1a7a3bb8eaaf5e50e0ad342afb33b36"},
+    {file = "pytest_asyncio-0.20.3-py3-none-any.whl", hash = "sha256:f129998b209d04fcc65c96fc85c11e5316738358909a8399e93be553d7656442"},
+]
+
+[package.dependencies]
+pytest = ">=6.1.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "six"
@@ -408,4 +427,4 @@ all = ["asttokens (>=2.0.0,<3.0.0)", "pure_eval (<1.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10 <4.0"
-content-hash = "9e8e0286311e7ea1f0ee1e11a8632e586b5679351759d95889ef4e4e0eec0dd4"
+content-hash = "f5e324252e2859b8d2ef21fb103fc1ca0add885e792e5a2d5ea9f7a2ebe4e49b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,15 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.10 <4.0"
-varname = { extras = ["asttokens"], version = "^0.10.0" }
-asttokens = "^2.2.1"
+varname = { extras = ["asttokens"], version = "~0.10.0" }
+asttokens = "~2.2.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.1.0"
 mypy = "^0.991"
 flake8 = "^6.0.0"
 pytest = "^7.2.1"
+pytest-asyncio = "^0.20.3"
 
 [build-system]
 requires = ["poetry-core"]
@@ -34,3 +35,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = "-p megamock.plugins.pytest"
+asyncio_mode = "auto"

--- a/tests/simple_app/async_portion.py
+++ b/tests/simple_app/async_portion.py
@@ -1,0 +1,7 @@
+async def an_async_function(arg: str) -> str:
+    return arg
+
+
+class SomeClassWithAsyncMethods:
+    async def some_method(self, arg: str) -> str:
+        return arg

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -1,9 +1,11 @@
+import asyncio
+import inspect
 from unittest import mock
 
 import pytest
 
 from megamock import MegaMock
-from megamock.megamocks import AttributeTrackingBase, NonCallableMegaMock
+from megamock.megamocks import AsyncMegaMock, AttributeTrackingBase, NonCallableMegaMock
 from megamock.megapatches import MegaPatch
 from tests.conftest import SomeClass
 from tests.simple_app.bar import Bar
@@ -41,6 +43,11 @@ class TestMegaMock:
 
     def test_return_value_when_no_args(self) -> None:
         assert isinstance(MegaMock()(), MegaMock)
+
+    def test_side_effect_value(self) -> None:
+        mega_mock = MegaMock(side_effect=lambda: 5)
+
+        assert mega_mock() == 5
 
     class TestMockingAClass:
         def test_classes_default_to_instance(self) -> None:
@@ -236,3 +243,27 @@ class TestMegaMock:
                 .stacktrace[0]
                 .filename.endswith("test_megamocks.py")
             )
+
+    class TestAsyncMock:
+        def test_async_mock_basics(self) -> None:
+            mega_mock = AsyncMegaMock()
+            assert asyncio.iscoroutinefunction(mega_mock) is True
+            assert inspect.isawaitable(mega_mock()) is True
+
+        async def test_function_side_effect(self) -> None:
+            mega_mock = AsyncMegaMock(side_effect=lambda: 5)
+
+            result = await mega_mock()
+            assert result == 5
+
+        def test_exception_side_effect(self) -> None:
+            pass
+
+        def test_iterable_side_effect(self) -> None:
+            pass
+
+        def test_return_value_provided(self) -> None:
+            pass
+
+        def test_defaults_to_async_mega_mock_return(self) -> None:
+            pass

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -256,14 +256,36 @@ class TestMegaMock:
             result = await mega_mock()
             assert result == 5
 
-        def test_exception_side_effect(self) -> None:
-            pass
+        async def test_exception_side_effect(self) -> None:
+            mega_mock = AsyncMegaMock(side_effect=Exception("whoops!"))
 
-        def test_iterable_side_effect(self) -> None:
-            pass
+            with pytest.raises(Exception) as exc:
+                await mega_mock()
 
-        def test_return_value_provided(self) -> None:
-            pass
+            assert str(exc.value) == "whoops!"
 
-        def test_defaults_to_async_mega_mock_return(self) -> None:
-            pass
+        async def test_iterable_side_effect(self) -> None:
+            mega_mock = AsyncMegaMock(side_effect=[1, 2, 3])
+
+            first = await mega_mock()
+            second = await mega_mock()
+            third = await mega_mock()
+
+            assert [first, second, third] == [1, 2, 3]
+
+        async def test_return_value_provided(self) -> None:
+            mega_mock = AsyncMegaMock(return_value=25)
+
+            assert await mega_mock() == 25
+
+        async def test_defaults_to_async_mega_mock_return(self) -> None:
+            assert isinstance(AsyncMegaMock(), AsyncMegaMock)
+
+            await AsyncMegaMock()()
+
+        async def test_altering_return_value(self) -> None:
+            mega_mock = AsyncMegaMock()
+            mega_mock.return_value.return_value = 5
+
+            result = await mega_mock()
+            assert await result() == 5

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -332,3 +332,21 @@ class TestMegaMock:
 
             with pytest.raises(TypeError):
                 await mega_mock()
+
+        async def test_await_args(self) -> None:
+            mega_mock = AsyncMegaMock()
+
+            await mega_mock("foo", keyword_arg="bar")
+            assert mega_mock.await_args == mock.call("foo", keyword_arg="bar")
+
+        async def test_await_args_list(self) -> None:
+            mega_mock = AsyncMegaMock()
+
+            await mega_mock("first")
+            await mega_mock("second", keyword_arg="kwsecond")
+
+            expected_await_args_list = [
+                mock.call("first"),
+                mock.call("second", keyword_arg="kwsecond"),
+            ]
+            assert mega_mock.await_args_list == expected_await_args_list

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -1,6 +1,7 @@
 import pytest
 from megamock import MegaPatch
 from megamock.megapatches import MegaMock
+from tests.simple_app.async_portion import SomeClassWithAsyncMethods, an_async_function
 from tests.simple_app.bar import some_func, Bar
 from tests.simple_app.foo import Foo, bar, foo_instance
 from tests.simple_app.foo import Foo as OtherFoo
@@ -174,3 +175,15 @@ class TestMegaPatchObject:
 
         assert Foo("s").moo == "cow"
         assert foo_instance.moo == "moooo"
+
+
+class TestAsyncPatching:
+    async def test_patching_async_function(self) -> None:
+        MegaPatch.it(an_async_function, return_value="val")
+
+        assert await an_async_function("s") == "val"
+
+    async def test_patching_async_method(self) -> None:
+        MegaPatch.it(SomeClassWithAsyncMethods.some_method, return_value="val")
+
+        assert await (SomeClassWithAsyncMethods().some_method("s")) == "val"


### PR DESCRIPTION
This adds `async` support. In the process of writing this, some other issues were encountered and fixed.

- Add `AsyncMegaMock`. Note that if an async function is passed in as the spec of a `MegaMock`, it will also support async functionality
- Add `dist` to `.gitignore`, which is where built packages go
- Update readme
- Adjust `__setattr_` logic so that deligated properties in the `mock` base classes are properly set
- Updated dependencies
- Added tests