### PR TITLE
#5 Add `UseRealLogic`

### DIFF
--- a/megamock/__init__.py
+++ b/megamock/__init__.py
@@ -52,4 +52,9 @@ def start_import_mod() -> None:
     builtins.__import__ = new_import
 
 
-__all__ = ["MegaPatch", "MegaMock", "start_import_mod"]
+__all__ = [
+    "MegaMock",
+    "MegaPatch",
+    "start_import_mod",
+    "UseRealLogic",
+]

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -281,23 +281,6 @@ class _MegaMockMixin:
                 AttributeAssignment.for_current_stack(key, value)
             )
 
-    # def __call__(self, *args: Any, **kwargs: Any) -> Any:
-    #     if self.return_value is UseRealLogic:
-    #         if not self.megamock_spec:
-    #             raise SpecRequiredException()
-    #         return self.megamock_spec(*args, **kwargs)
-    #     base_class = super()
-    #     return base_class(*args, **kwargs)  # type: ignore
-
-    # if isinstance(self, MegaMock):
-    #     return super(mock.MagicMock, self).__call__(*args, **kwds)
-    # elif isinstance(self, AsyncMegaMock):
-    #     return super(mock.AsyncMock, self).__call__(*args, **kwds)
-    # elif isinstance(self, NonCallableMegaMock):
-    #     return super(mock.NonCallableMagicMock, self).__call__(*args, **kwds)
-    # else:
-    #     raise TypeError("Noncallable type not supported")
-
 
 class MegaMock(_MegaMockMixin, mock.MagicMock):
     @staticmethod

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -326,10 +326,13 @@ class MegaMock(_MegaMockMixin, mock.MagicMock):
                 if not self.megamock_spec:
                     raise SpecRequiredException()
                 if self.megamock_parent:
-                    # convert from bound method to unbound method
-                    return self.megamock_spec.__func__(
-                        self.megamock_parent, *args, **kwargs
-                    )
+                    if hasattr(self.megamock_spec, "__func__"):
+                        # convert from bound method to unbound method
+                        return self.megamock_spec.__func__(
+                            self.megamock_parent, *args, **kwargs
+                        )
+                    # instance of a class Mock
+                    return self.megamock_spec(self.megamock_parent, *args, **kwargs)
                 return self.megamock_spec(*args, **kwargs)
             result = wrapped(*args, **kwargs)
             if not isinstance(result, _MegaMockMixin) and isinstance(

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -221,11 +221,6 @@ class _MegaMockMixin:
     def _get_child_mock(self, /, **kw) -> MegaMock:
         return MegaMock(_parent_mega_mock=self, **kw)
 
-    # def __getattribute__(self, name: str) -> Any:
-    #     if name != "__dict__" and self.__dict__.get("_use_real", False):
-    #         return getattr(self.__dict__["megamock_spec"], name)
-    #     return super().__getattribute__(name)
-
     def __getattr__(self, key) -> Any:
         if key not in ("megamock_spy", "megamock_spied_access") and self.megamock_spy:
             result = getattr(self.megamock_spy, key)

--- a/megamock/type_util.py
+++ b/megamock/type_util.py
@@ -1,0 +1,14 @@
+from typing import TypeVar, Union
+
+
+class _MISSING:
+    """
+    Class to indicate a missing value
+    """
+
+
+_T = TypeVar("_T")
+
+Opt = Union[_T, _MISSING]
+
+MISSING = _MISSING()

--- a/tests/simple_app/foo.py
+++ b/tests/simple_app/foo.py
@@ -27,5 +27,8 @@ class Foo:
     def some_method(self) -> str:
         return "value"
 
+    def what_moos(self) -> str:
+        return f"The {self.moo} moos"
+
 
 foo_instance = Foo("global")

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -5,7 +5,12 @@ from unittest import mock
 import pytest
 
 from megamock import MegaMock
-from megamock.megamocks import AsyncMegaMock, AttributeTrackingBase, NonCallableMegaMock
+from megamock.megamocks import (
+    AsyncMegaMock,
+    AttributeTrackingBase,
+    NonCallableMegaMock,
+    UseRealLogic,
+)
 from megamock.megapatches import MegaPatch
 from tests.conftest import SomeClass
 from tests.simple_app.bar import Bar
@@ -350,3 +355,22 @@ class TestMegaMock:
                 mock.call("second", keyword_arg="kwsecond"),
             ]
             assert mega_mock.await_args_list == expected_await_args_list
+
+    class TestUseRealLogic:
+        def test_will_use_real_method_values(self) -> None:
+            mega_mock = MegaMock(Foo("s"), spec_set=False)
+            mega_mock._s = "the value"
+
+            # check preconditions
+            assert isinstance(mega_mock.some_method(), MegaMock)
+
+            mega_mock.some_method.return_value = UseRealLogic
+
+            assert mega_mock.some_method() == "value"
+
+        def test_real_logic_uses_mock_object_values(self) -> None:
+            mega_mock = MegaMock(Foo("s"))
+            mega_mock.moo = "fox"
+            mega_mock.what_moos.return_value = UseRealLogic
+
+            assert mega_mock.what_moos() == "The fox moos"

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -359,7 +359,6 @@ class TestMegaMock:
     class TestUseRealLogic:
         def test_will_use_real_method_values(self) -> None:
             mega_mock = MegaMock(Foo("s"), spec_set=False)
-            mega_mock._s = "the value"
 
             # check preconditions
             assert isinstance(mega_mock.some_method(), MegaMock)
@@ -370,6 +369,13 @@ class TestMegaMock:
 
         def test_real_logic_uses_mock_object_values(self) -> None:
             mega_mock = MegaMock(Foo("s"))
+            mega_mock.moo = "fox"
+            mega_mock.what_moos.return_value = UseRealLogic
+
+            assert mega_mock.what_moos() == "The fox moos"
+
+        def test_real_logic_with_class_instance_shortcut(self) -> None:
+            mega_mock = MegaMock(Foo)
             mega_mock.moo = "fox"
             mega_mock.what_moos.return_value = UseRealLogic
 

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -1,5 +1,6 @@
 import pytest
 from megamock import MegaPatch
+from megamock.megamocks import UseRealLogic
 from megamock.megapatches import MegaMock
 from tests.simple_app.async_portion import SomeClassWithAsyncMethods, an_async_function
 from tests.simple_app.bar import some_func, Bar
@@ -96,6 +97,21 @@ class TestMegaPatchPatching:
         MegaPatch.it(OtherFoo.some_method, return_value="sm")
 
         assert Foo("s").some_method() == "sm"
+
+    @pytest.mark.xfail
+    def test_patch_with_real_logic(self) -> None:
+        # this currently fails because the object created by autospec
+        # isn't using the MegaMock code path
+        MegaPatch.it(Foo.some_method, return_value=UseRealLogic)
+
+        assert Foo("s").some_method() == "a"
+
+    def test_patch_class_and_enable_real_logic(self) -> None:
+        megapatch = MegaPatch.it(Foo)
+
+        megapatch.return_value.some_method.return_value = UseRealLogic
+
+        assert Foo("s").some_method() == "value"
 
 
 class TestMegaPatchAutoStart:


### PR DESCRIPTION
This adds a new object, `UseRealLogic`, which is used to indicate that the real logic should be used. The expected use case for enabling the real logic of a method of a mocked class.

Example:
```
from ... import Foo

mega_mock = MegaMock(Foo)
mock_class_instance = mega_mock.return_value
mock_class_instance.target_method.return_value = UseRealLogic
```

Then when `target_method(...)` is called, the actual logic will be used.

This is an uncommon use case, but can be helpful when you want a class _mostly_ mocked out.