### PR TITLE
#34 #38 refactor for `megamock` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ def test_something(...):
 
 You can focus your production code on creating an intuitive, "batteries included" interface for developers
 without making compromises for testability.
+
+`MegaMock` objects have the same attributes as regular `MagicMock`s plus one more - `megamock`.
+For example, `my_mega_mock.megamock.spy` is the object being spied, if set.
+
 Please see the guidance section (TODO) for more information on how and when you would use MegaMock.
 
 ### Use Case Examples
@@ -180,9 +184,9 @@ spied_class.some_method.call_args_list  # same as wraps
 
 # check whether a value was accessed
 # if things aren't as expected, you can pull up the debugger and see the stack traces
-assert len(spied_class.megamock_spied_access["some_attribute"]) == 1
+assert len(spied_class.megamock.spied_access["some_attribute"]) == 1
 
-spy_access_list = spied_class.megamock_spied_access["some_attribute"]
+spy_access_list = spied_class.megamock.spied_access["some_attribute"]
 spy_access: SpyAccess = spy_access_list[0]
 spy_access.attr_value  # shallow copy of what was returned
 spy_access.stacktrace  # where the access happened
@@ -309,12 +313,13 @@ do_something_that_invokes_that_function(...)
 
 # Debugging tools
 In addition to mocking capability, `MegaMock` objects can also help
-you debug. `MegaMock` objects have the attribute `megamock_attr_assignments`, which keeps a record of what attributes
+you debug. The `attr_assignments` dictionary, found under the `megamock`
+attribute in `MegaMock` objects, keep a record of what attributes
 were assigned, when, and what the value was. This object is a dictionary
 where the key is the attribute name, and the value is a list of
 `AttributeAssignment` objects.
 
-There is also `megamock_spied_access`, which is similar, but for
+There is also `spied_access`, which is similar, but for
 objects that are spied.
 
 If an attribute is coming out of a complex branch of logic with a value
@@ -330,4 +335,4 @@ To easily view the stacktrace in the IDE, there's a special property,
 
 ![MegaMock](docs/img/megamock-cropped.png)
 
-I didn't say it was a big art gallery.
+Nobody said it was a big art gallery. Feel free to submit a PR that helps fix that.

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -148,7 +148,7 @@ class MegaPatch(Generic[T]):
         )
 
         if isinstance(thing, _MegaMockMixin):
-            thing = thing.megamock_spec
+            thing = thing.megamock.spec
         if isinstance(thing, cached_property):
             thing = thing.func  # type: ignore
 

--- a/megamock/type_util.py
+++ b/megamock/type_util.py
@@ -1,7 +1,7 @@
 from typing import TypeVar, Union
 
 
-class _MISSING:
+class MISSING_TYPE:
     """
     Class to indicate a missing value
     """
@@ -10,6 +10,6 @@ class _MISSING:
 _T = TypeVar("_T")
 
 
-Opt = Union[_T, _MISSING]
+Opt = Union[_T, MISSING_TYPE]
 
-MISSING = _MISSING()
+MISSING = MISSING_TYPE()

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -155,7 +155,7 @@ class TestMegaMock:
             legacy_mock = mock.create_autospec(SomeClass)
             mega_mock = MegaMock.from_legacy_mock(legacy_mock, spec=SomeClass)
 
-            assert mega_mock.megamock_spec is SomeClass
+            assert mega_mock.megamock.spec is SomeClass
             assert hasattr(mega_mock, "b")
 
             assert isinstance(mega_mock.b, MegaMock)
@@ -171,7 +171,7 @@ class TestMegaMock:
 
             mega_mock = MegaMock.from_legacy_mock(legacy_mock, spec=SomeClass)
 
-            assert mega_mock.megamock_spec is SomeClass
+            assert mega_mock.megamock.spec is SomeClass
             assert hasattr(mega_mock, "b")
 
             assert isinstance(mega_mock.b, MegaMock)
@@ -184,7 +184,7 @@ class TestMegaMock:
 
             mega_mock = MegaMock.from_legacy_mock(legacy_mock, spec=SomeClass)
 
-            assert mega_mock.megamock_spec is SomeClass
+            assert mega_mock.megamock.spec is SomeClass
             assert hasattr(mega_mock, "b")
 
             assert isinstance(mega_mock.b, MegaMock)
@@ -210,8 +210,8 @@ class TestMegaMock:
 
             mega_mock.foo = "bar"
 
-            assert "foo" in mega_mock.megamock_attr_assignments
-            stacktrace = mega_mock.megamock_attr_assignments["foo"][0].stacktrace
+            assert "foo" in mega_mock.megamock.attr_assignments
+            stacktrace = mega_mock.megamock.attr_assignments["foo"][0].stacktrace
             assert len(stacktrace) > 5
             for frame in stacktrace:
                 assert "/megamocks.py" not in frame.filename
@@ -223,11 +223,11 @@ class TestMegaMock:
 
             mega_mock.foo = "second"
 
-            assert len(mega_mock.megamock_attr_assignments["foo"]) == 2
-            assert len(mega_mock.megamock_attr_assignments["bar"]) == 1
+            assert len(mega_mock.megamock.attr_assignments["foo"]) == 2
+            assert len(mega_mock.megamock.attr_assignments["bar"]) == 1
 
-            assert mega_mock.megamock_attr_assignments["foo"][0].attr_value == "foo"
-            assert mega_mock.megamock_attr_assignments["foo"][1].attr_value == "second"
+            assert mega_mock.megamock.attr_assignments["foo"][0].attr_value == "foo"
+            assert mega_mock.megamock.attr_assignments["foo"][1].attr_value == "second"
 
     class TestWraps:
         def test_wraps_object(self) -> None:
@@ -272,9 +272,9 @@ class TestMegaMock:
             mega_mock.moo
             mega_mock.helpful_manager
 
-            assert len(mega_mock.megamock_spied_access) == 3
+            assert len(mega_mock.megamock.spied_access) == 3
             assert (
-                mega_mock.megamock_spied_access["z"][0]
+                mega_mock.megamock.spied_access["z"][0]
                 .stacktrace[0]
                 .filename.endswith("test_megamocks.py")
             )


### PR DESCRIPTION
This moves the `megamock_` prefixed attributes under a `MegaMockAttributes` object. They are available under the `megamock` attribute on a `MegaMock` object. Also has some other minor refactors, such as renaming `_MISSING` to `MISSING_TYPE`