### PR TITLE
Improve typing and UseRealLogic

### DIFF
--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -31,6 +31,9 @@ class _UseRealLogic:
     Class to indicate that the real logic should be used
     """
 
+    def __call__(self, target_callable: Callable) -> None:
+        cast(MegaMock, target_callable).return_value = UseRealLogic
+
 
 UseRealLogic = _UseRealLogic()
 

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -384,6 +384,20 @@ class TestMegaMock:
 
             assert mega_mock.what_moos() == "The fox moos"
 
+        def test_function_call_on_mock_object(self) -> None:
+            mega_mock = MegaMock(Foo("s"))
+            mega_mock.moo = "fox"
+            UseRealLogic(mega_mock.what_moos)
+
+            assert mega_mock.what_moos() == "The fox moos"
+
+        def test_function_call_on_cast_object(self) -> None:
+            mega_mock = MegaMock(Foo("s"))
+            mega_mock.moo = "fox"
+            UseRealLogic(mega_mock.megacast.what_moos)
+
+            assert mega_mock.megacast.what_moos() == "The fox moos"
+
     class TestMegaCast:
         def test_cast_types_to_the_spec_with_type(self) -> None:
             mega_mock = MegaMock(Foo)

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -27,7 +27,7 @@ class TestMegaPatchPatching:
         with pytest.raises(TypeError):
             Foo("s")()  # type: ignore
 
-    def test_patch_class_instance(self) -> None:
+    def test_patch_class_instance_from_type(self) -> None:
         patch = MegaPatch.it(Foo)
         patch.return_value.megacast.z = "b"
 
@@ -109,7 +109,7 @@ class TestMegaPatchPatching:
     def test_patch_class_and_enable_real_logic(self) -> None:
         megapatch = MegaPatch.it(Foo)
 
-        megapatch.return_value.some_method.return_value = UseRealLogic
+        UseRealLogic(megapatch.megainstance.some_method)
 
         assert Foo("s").some_method() == "value"
 
@@ -154,6 +154,11 @@ class TestMegaPatchReturnValue:
         patch = MegaPatch.it(Foo)
 
         assert patch.return_value is Foo("s")
+
+    def test_megainstance_for_class_is_the_instance_object(self) -> None:
+        patch = MegaPatch.it(Foo)
+
+        assert patch.megainstance is Foo("s")
 
     def test_provided_return_value_is_the_return_value(self) -> None:
         ret_val: MegaMock = MegaMock()


### PR DESCRIPTION
You can now do this:

`UseRealLogic(my_mock.megainstance.some_func)`

The reason for this change is that casting is a core part of the MegaMock benefit - it allows for autocompletion. However the static type analysis will complain if you try to set `return_value` on a function using the original type. This works around that.

This also adds `megainstance` to `MegaPatch`, which is a shortcut to `self.mock.megainstance`