### PR TITLE
#23 Add support for mocking context managers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     "python.testing.pytestEnabled": true,
     "python.analysis.autoImportCompletions": true,
     "python.analysis.indexing": true,
-    "python.linting.flake8Enabled": true
+    "python.linting.flake8Enabled": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    }
 }

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -1,26 +1,17 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass, field
 import re
 import time
 import traceback
 from abc import ABCMeta
 from collections import defaultdict
+from dataclasses import dataclass, field
 from inspect import isawaitable, isclass, iscoroutinefunction
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    Literal,
-    TypeVar,
-    cast,
-    overload,
-)
+from typing import Any, Callable, Generic, Literal, TypeVar, cast, overload
 from unittest import mock
 
-from megamock.type_util import MISSING_TYPE, MISSING
-
+from megamock.type_util import MISSING, MISSING_TYPE
 
 T = TypeVar("T")
 U = TypeVar("U")

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -11,7 +11,6 @@ from inspect import isawaitable, isclass, iscoroutinefunction
 from typing import (
     Any,
     Callable,
-    Generator,
     Generic,
     Literal,
     TypeVar,
@@ -227,23 +226,6 @@ class _MegaMockMixin(Generic[T, U]):
                 autospeced_legacy_mock = mock.create_autospec(
                     spec, spec_set=spec_set, instance=instance, **kwargs
                 )
-                # support context manager ("with" statement)
-
-                def enter() -> Generator:
-                    yield self._get_child_mock()
-
-                def exit(exc_type, exc_value, traceback) -> None:
-                    return None
-
-                try:
-                    autospeced_legacy_mock.__enter__ = enter
-                    autospeced_legacy_mock.__exit__ = exit
-                except AttributeError:
-                    pass
-
-                # fix return value thingy
-                autospeced_legacy_mock._mock_delegate = None
-
                 megamock_attrs._wrapped_mock = autospeced_legacy_mock
             else:
                 # not wrapping a Mock object, so do init for super

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -104,23 +104,32 @@ class MegaPatch(Generic[T, U]):
         with my_context_manager() as val:
             assert val == "foo"
         """
-        self.return_value.__enter__.return_value = new_return_value  # type: ignore
+        try:
+            self.return_value.__enter__.return_value = new_return_value  # type: ignore
+        except AttributeError:
+            raise ValueError("Not a context manager")
 
     def set_context_manager_side_effect(self, new_side_effect: Any) -> None:
         """
-        Use to set the side effect of a context manager. As with
+        Use to set the side effect when entering the context manager. As with
         normal side-effect usage, an exception will result in it being raised,
         and an iterable will change the result on subsequent calls
         """
-        self.return_value.__enter__.side_effect = new_side_effect  # type: ignore
+        try:
+            self.return_value.__enter__.side_effect = new_side_effect  # type: ignore
+        except AttributeError:
+            raise ValueError("Not a context manager")
 
     def set_context_manager_exit_side_effect(self, new_side_effect: Any) -> None:
         """
-        Use to set the side effect of a context manager. As with
+        Use to set the side effect when exiting the context manager. As with
         normal side-effect usage, an exception will result in it being raised,
         and an iterable will change the result on subsequent calls
         """
-        self.return_value.__exit__.side_effect = new_side_effect  # type: ignore
+        try:
+            self.return_value.__exit__.side_effect = new_side_effect  # type: ignore
+        except AttributeError:
+            raise ValueError("Not a context manager")
 
     def start(self) -> None:
         # support for pytest-mock and similar

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -94,6 +94,34 @@ class MegaPatch(Generic[T, U]):
     def return_value(self) -> MegaMock[T, U]:
         return cast(MegaMock[T, U], self._return_value)
 
+    def set_context_manager_return_value(self, new_return_value: Any) -> None:
+        """
+        Use to modify the result of entering a context manager
+
+        megapatch = MegaPatch.it(my_context_manager)
+        megapatch.set_context_manager_return_value("foo")
+
+        with my_context_manager() as val:
+            assert val == "foo"
+        """
+        self.return_value.__enter__.return_value = new_return_value  # type: ignore
+
+    def set_context_manager_side_effect(self, new_side_effect: Any) -> None:
+        """
+        Use to set the side effect of a context manager. As with
+        normal side-effect usage, an exception will result in it being raised,
+        and an iterable will change the result on subsequent calls
+        """
+        self.return_value.__enter__.side_effect = new_side_effect  # type: ignore
+
+    def set_context_manager_exit_side_effect(self, new_side_effect: Any) -> None:
+        """
+        Use to set the side effect of a context manager. As with
+        normal side-effect usage, an exception will result in it being raised,
+        and an iterable will change the result on subsequent calls
+        """
+        self.return_value.__exit__.side_effect = new_side_effect  # type: ignore
+
     def start(self) -> None:
         # support for pytest-mock and similar
         if not hasattr(self._mocker, "stopall"):

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
-from functools import cached_property
+
 import inspect
 import logging
 import sys
+from functools import cached_property
 from types import ModuleType
 from typing import Any, Callable, Generic, TypeVar, cast
 from unittest import mock
+
 from varname import argname  # type: ignore
 
 from megamock.import_references import References
-from megamock.megamocks import _MegaMockMixin, _UseRealLogic, MegaMock
+from megamock.megamocks import MegaMock, _MegaMockMixin, _UseRealLogic
 
 logger = logging.getLogger(__name__)
 

--- a/megamock/megas.py
+++ b/megamock/megas.py
@@ -30,36 +30,36 @@ class Mega:
             return False
         return True
 
+    @property
+    def _mm(self) -> MegaMock:
+        return cast(MegaMock, self._func)
+
     def called_once_with(self, *args, **kwargs) -> bool:
         """
         Return true if the mock was called exactly once and with the specified
         arguments
         """
         return self._check_mock_assertion(
-            lambda: cast(MegaMock, self._func).assert_called_once_with(*args, **kwargs)
+            lambda: self._mm.assert_called_once_with(*args, **kwargs)
         )
 
     def called_once(self) -> bool:
         """
         Return true if the mock was called exactly once
         """
-        return self._check_mock_assertion(
-            lambda: cast(MegaMock, self._func).assert_called_once()
-        )
+        return self._check_mock_assertion(lambda: self._mm.assert_called_once())
 
     def called(self) -> bool:
         """
         Return true if the mock was called
         """
-        return cast(MegaMock, self._func).called
+        return self._mm.called
 
     def not_called(self) -> bool:
         """
         Return true if the mock was not called
         """
-        return self._check_mock_assertion(
-            lambda: cast(MegaMock, self._func).assert_not_called()
-        )
+        return self._check_mock_assertion(lambda: self._mm.assert_not_called())
 
     def called_with(self, *args, **kwargs) -> bool:
         """
@@ -67,7 +67,7 @@ class Mega:
         arguments
         """
         return self._check_mock_assertion(
-            lambda: cast(MegaMock, self._func).assert_called_with(*args, **kwargs)
+            lambda: self._mm.assert_called_with(*args, **kwargs)
         )
 
     def any_call(self, *args, **kwargs) -> bool:
@@ -76,7 +76,7 @@ class Mega:
         at any point in time
         """
         return self._check_mock_assertion(
-            lambda: cast(MegaMock, self._func).assert_any_call(*args, **kwargs)
+            lambda: self._mm.assert_any_call(*args, **kwargs)
         )
 
     def has_calls(self, calls: Sequence[Call], any_order=False) -> bool:
@@ -88,7 +88,7 @@ class Mega:
         Extra calls are ignored.
         """
         return self._check_mock_assertion(
-            lambda: cast(MegaMock, self._func).assert_has_calls(calls, any_order)
+            lambda: self._mm.assert_has_calls(calls, any_order)
         )
 
     @property
@@ -96,24 +96,24 @@ class Mega:
         """
         Return the last call made to the mock
         """
-        return cast(MegaMock, self._func).call_args
+        return self._mm.call_args
 
     @property
     def call_args_list(self) -> list[Call]:
         """
         Return the list of all calls made to the mock
         """
-        return cast(MegaMock, self._func).call_args_list
+        return self._mm.call_args_list
 
     @property
     def call_count(self) -> int:
         """
         Return the number of times the mock was called
         """
-        return cast(MegaMock, self._func).call_count
+        return self._mm.call_count
 
     def use_real_logic(self) -> None:
         """
         Helper function to have a MegaMock object use the real logic
         """
-        cast(MegaMock, self._func).return_value = UseRealLogic
+        self._mm.return_value = UseRealLogic

--- a/megamock/megas.py
+++ b/megamock/megas.py
@@ -32,6 +32,9 @@ class Mega:
 
     @property
     def _mm(self) -> MegaMock:
+        """
+        Property to shorthand the cast to MegaMock
+        """
         return cast(MegaMock, self._func)
 
     def called_once_with(self, *args, **kwargs) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ build-backend = "poetry.core.masonry.api"
 [tool.pytest.ini_options]
 addopts = "-p megamock.plugins.pytest"
 asyncio_mode = "auto"
+
+[tool.isort]
+profile = "black"

--- a/tests/simple_app/bar.py
+++ b/tests/simple_app/bar.py
@@ -1,3 +1,7 @@
+from contextlib import contextmanager
+from typing import Generator
+
+
 def some_func(val: str) -> str:
     return val + "a"
 
@@ -5,3 +9,8 @@ def some_func(val: str) -> str:
 class Bar:
     def __call__(self) -> str:
         return "called"
+
+
+@contextmanager
+def some_context_manager() -> Generator[str, None, None]:
+    yield "foo"

--- a/tests/simple_app/locks.py
+++ b/tests/simple_app/locks.py
@@ -1,0 +1,11 @@
+class SomeLock:
+    def __init__(self) -> None:
+        self.acquired = False
+
+    def __enter__(self) -> None:
+        if self.acquired is True:
+            raise Exception("Could not acquire lock")
+        self.acquired = True
+
+    def __exit__(self, *args, **kwargs) -> None:
+        self.acquired = False

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -1,6 +1,6 @@
 import asyncio
-from contextlib import contextmanager
 import inspect
+from contextlib import contextmanager
 from typing import Generator, cast
 from unittest import mock
 

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -1,6 +1,7 @@
 import asyncio
+from contextlib import contextmanager
 import inspect
-from typing import cast
+from typing import Generator, cast
 from unittest import mock
 
 import pytest
@@ -480,3 +481,73 @@ class TestMegaMock:
             mega_mock = MegaMock.it(Foo, instance=False)
 
             mega_mock.megainstance.some_method()
+
+    class TestMockingContextManager:
+        @pytest.fixture(autouse=True)
+        def setup(self) -> None:
+            self.before = False
+            self.after = False
+
+            # a test context manager
+            @contextmanager
+            def my_context_manager() -> Generator:
+                self.before = True
+                yield "foo"
+                self.after = True
+
+            self.context_manager = my_context_manager
+
+        def test_preconditions(self) -> None:
+            # not a real test
+            # just ensure the tests are set up correctly
+
+            assert self.before is False
+
+            with self.context_manager() as value:
+                assert self.before is True
+                assert value == "foo"
+                assert self.after is False
+
+            assert self.after is True
+
+        def test_mocking_context_manager(self) -> None:
+            mega_mock = MegaMock.it(self.context_manager)
+            mega_mock.return_value.return_value = "mocked"
+
+            with mega_mock() as val:
+                assert val == "mocked"
+
+            assert self.before is False
+            assert self.after is False
+
+        def test_use_real_logic(self) -> None:
+            mega_mock = MegaMock.it(self.context_manager())
+
+            Mega(mega_mock).use_real_logic()
+
+            with mega_mock as val:
+                assert val == "foo"
+
+            assert self.after is True
+
+        def test_attempting_to_use_non_contextmanager(self) -> None:
+            mega_mock = MegaMock.it(Foo)
+
+            with pytest.raises(TypeError) as exc:
+                with mega_mock:
+                    pass
+
+            assert (
+                str(exc.value)
+                == "'Foo' object does not support the context manager protocol"
+            )
+
+        def test_no_spec_supports_context_manager(self) -> None:
+            with MegaMock():
+                pass
+
+        def test_spy_supports_context_manager(self) -> None:
+            mega_mock = MegaMock.it(spy=self.context_manager())
+
+            with mega_mock as val:
+                assert val == "foo"

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -272,8 +272,7 @@ class TestNewCallable:
 
 class TestMegaPatchContextManager:
     def test_patch_context_manager(self) -> None:
-        megapatch = MegaPatch.it(some_context_manager)
-        megapatch.set_context_manager_return_value("foo")
+        MegaPatch.it(some_context_manager)
 
         with some_context_manager():
             pass
@@ -287,7 +286,7 @@ class TestMegaPatchContextManager:
 
     def test_set_side_effect_exception(self) -> None:
         megapatch = MegaPatch.it(some_context_manager)
-        megapatch.set_context_manager_side_effect(Exception("boo!"))
+        megapatch.set_context_manager_side_effect(Exception())
 
         with pytest.raises(Exception):
             with some_context_manager():
@@ -331,3 +330,15 @@ class TestMegaPatchContextManager:
         with lock:
             with lock:
                 pass
+
+    def test_setting_return_value_for_non_context_manager(self) -> None:
+        with pytest.raises(ValueError):
+            MegaPatch.it(Foo).set_context_manager_return_value("foo")
+
+    def test_setting_side_effect_for_non_context_manager(self) -> None:
+        with pytest.raises(ValueError):
+            MegaPatch.it(Foo).set_context_manager_side_effect(Exception())
+
+    def test_setting_exit_side_effect_for_non_context_manager(self) -> None:
+        with pytest.raises(ValueError):
+            MegaPatch.it(Foo).set_context_manager_exit_side_effect(Exception())

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -10,6 +10,7 @@ from tests.simple_app.foo import Foo, bar, foo_instance
 from tests.simple_app.foo import Foo as OtherFoo
 from tests.simple_app import foo
 from tests.simple_app.helpful_manager import HelpfulManager
+from tests.simple_app.locks import SomeLock
 from tests.simple_app.nested_classes import NestedParent
 from tests.simple_app.uses_nested_classes import (
     get_nested_class_function_value,
@@ -269,7 +270,7 @@ class TestNewCallable:
         assert str(exc.value) == "Cannot use 'autospec' and 'new_callable' together"
 
 
-class TestMegaPatchContextManagerFromGenerator:
+class TestMegaPatchContextManager:
     def test_patch_context_manager(self) -> None:
         megapatch = MegaPatch.it(some_context_manager)
         megapatch.set_context_manager_return_value("foo")
@@ -313,6 +314,20 @@ class TestMegaPatchContextManagerFromGenerator:
 
         assert str(exc.value) == "Error on file close"
 
+    def test_using_class(self) -> None:
+        lock = SomeLock()
 
-class TestMegaPatchContextManagerClass:
-    pass  # TODO
+        # check precondition, should raise exception
+        with pytest.raises(Exception):
+            with lock:
+                with lock:
+                    pass
+
+        MegaPatch.it(SomeLock)
+
+        lock = SomeLock()
+
+        # since logic is mocked out, should not raise
+        with lock:
+            with lock:
+                pass

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -1,20 +1,23 @@
 from unittest import mock
+
 import pytest
+
 from megamock import MegaPatch
 from megamock.megamocks import UseRealLogic
 from megamock.megapatches import MegaMock
 from megamock.megas import Mega
-from tests.simple_app.async_portion import SomeClassWithAsyncMethods, an_async_function
-from tests.simple_app.bar import some_context_manager, some_func, Bar
-from tests.simple_app.foo import Foo, bar, foo_instance
-from tests.simple_app.foo import Foo as OtherFoo
 from tests.simple_app import foo
+from tests.simple_app.async_portion import SomeClassWithAsyncMethods, an_async_function
+from tests.simple_app.bar import Bar, some_context_manager, some_func
+from tests.simple_app.foo import Foo
+from tests.simple_app.foo import Foo as OtherFoo
+from tests.simple_app.foo import bar, foo_instance
 from tests.simple_app.helpful_manager import HelpfulManager
 from tests.simple_app.locks import SomeLock
 from tests.simple_app.nested_classes import NestedParent
 from tests.simple_app.uses_nested_classes import (
-    get_nested_class_function_value,
     get_nested_class_attribute_value,
+    get_nested_class_function_value,
 )
 
 


### PR DESCRIPTION
- Add "Advanced Use Cases" to guidance
- Add logic to support using `MegaMock` as a context manager
- Add `using_real_logic()` method to `MegaMock` objects
- Add `set_context_manager_return_value`, `set_context_manager_side_effect`, and `set_context_manager_exit_side_effect` to the `MegaPatch` class.
- Refactor `Mega` logic to use `_mm` instead of repeating `cast` a bunch of times
- Update tests
- Refactor guidance
- Update VS Code so that `isort` is being used on save, also resave some files to sort imports properly