### PR TITLE
#48 Fix eval warning

### DIFF
--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -240,7 +240,7 @@ class MegaPatch(Generic[T, U]):
         if isinstance(thing, cached_property):
             thing = thing.func  # type: ignore
 
-        passed_in_name = argname("thing", vars_only=False)
+        passed_in_name = argname("thing", func=MegaPatch.it, vars_only=False)
 
         module_path = MegaPatch._determine_module_path(thing, passed_in_name)
 


### PR DESCRIPTION
Fixed "pure eval" warning by providing the function parameter to `varname.argname`

Addresses #48 