### PR TITLE
#43 #65 Add linking (for class to instance)

### DIFF
--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -152,6 +152,8 @@ class _MegaMockMixin(Generic[T, U]):
     megamock: MegaMockAttributes = None  # type: ignore
     _wrapped_legacy_mock: _base_mock_types | None
     _mock_return_value_cache: Any | MISSING_TYPE = None
+    # link call behavior to this mock
+    _linked_mock: MegaMock[T, U] | None = None
 
     def __init__(
         self,
@@ -192,6 +194,7 @@ class _MegaMockMixin(Generic[T, U]):
         :param _parent_mega_mock: The parent MegaMock, for internal use
         """
         self.meganame = self._generate_meganame()
+        self._linked_mock = None
         megamock_attrs = MegaMockAttributes()
         self._wrapped_legacy_mock = None
         self._mock_return_value_cache = MISSING
@@ -428,6 +431,15 @@ class _MegaMockMixin(Generic[T, U]):
             self._wrapped_legacy_mock.__dict__.get("_mock_return_value") is UseRealLogic
         )
 
+    def link_to(self, other: MegaMock[T, U]) -> None:
+        self.__dict__["_linked_mock"] = other
+
+    def __repr__(self) -> str:
+        return (
+            f"<{self.__class__.__name__} name='{self._mock_name}' "
+            f"| {self.meganame}>"
+        )
+
 
 class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
     """
@@ -659,6 +671,9 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
                     # instance of a class Mock
                     return cast(Callable, spec)(self.megamock.parent, *args, **kwargs)
                 return cast(Callable, spec)(*args, **kwargs)
+            if self._linked_mock is not None:
+                # why is the mock not called as a bound method
+                return self._linked_mock(self, *args, **kwargs)
             result = wrapped(*args, **kwargs)
             if not isinstance(result, _MegaMockMixin) and isinstance(
                 result, mock.NonCallableMock | mock.NonCallableMagicMock

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -431,7 +431,11 @@ class _MegaMockMixin(Generic[T, U]):
             self._wrapped_legacy_mock.__dict__.get("_mock_return_value") is UseRealLogic
         )
 
-    def link_to(self, other: MegaMock[T, U]) -> None:
+    def _megalink_to(self, other: MegaMock[T, U]) -> None:
+        """
+        Link the call behavior to another mock. This is currently used by `MegaPatch.it`
+        to link the class (type) mock with the class (instance) mock.
+        """
         self.__dict__["_linked_mock"] = other
 
     def __repr__(self) -> str:

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -267,16 +267,23 @@ class MegaPatch(Generic[T, U]):
         if autostart:
             mega_patch.start()
 
+        MegaPatch._maybe_assign_link(parent_mock, passed_in_name, mega_patch)
+
+        return mega_patch
+
+    @staticmethod
+    def _maybe_assign_link(
+        parent_mock: _MegaMockMixin | None, passed_in_name: str, mega_patch: MegaPatch
+    ) -> None:
         if parent_mock is not None:
             assert passed_in_name
             this_name = passed_in_name.split(".")[-1]
             try:
-                cast(MegaMock, getattr(parent_mock.megainstance, this_name)).link_to(
-                    mega_patch.mock
-                )
+                cast(
+                    MegaMock, getattr(parent_mock.megainstance, this_name)
+                )._megalink_to(mega_patch.mock)
             except ValueError:
                 pass  # not a mock
-        return mega_patch
 
     @staticmethod
     def _new_return_value(

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -119,9 +119,20 @@ class TestMegaPatchPatching:
 
         assert Foo("s").some_method() == "value"
 
-    # https://github.com/JamesHutchison/megamock/issues/65
-    @pytest.mark.xfail
     def test_setting_side_effect(self) -> None:
+        MegaPatch.it(Foo.some_method, side_effect=Exception("Error!"))
+
+        with pytest.raises(Exception) as exc:
+            Foo("s").some_method()
+
+        assert str(exc.value) == "Error!"
+
+    @pytest.mark.xfail
+    def test_setting_side_effect_to_a_property(self) -> None:
+        # This doesn't work because side_effect requires making a call.
+        # If you really need to have a property that raises an exception,
+        # then you'll need to structure your code to call a function
+        # and then mock that function.
         MegaPatch.it(Foo.helpful_manager, side_effect=Exception("Error!"))
 
         with pytest.raises(Exception) as exc:

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -119,6 +119,41 @@ class TestMegaPatchPatching:
 
         assert Foo("s").some_method() == "value"
 
+    # https://github.com/JamesHutchison/megamock/issues/65
+    @pytest.mark.xfail
+    def test_setting_side_effect(self) -> None:
+        MegaPatch.it(Foo.helpful_manager, side_effect=Exception("Error!"))
+
+        with pytest.raises(Exception) as exc:
+            Foo("s").helpful_manager
+
+        assert str(exc.value) == "Error!"
+
+    def test_stacked_patching_return_value(self) -> None:
+        MegaPatch.it(Foo)
+        MegaPatch.it(Foo.some_method, return_value="new val")
+
+        assert Foo("s").some_method() == "new val"
+
+    def test_stacked_patching_side_effect(self) -> None:
+        MegaPatch.it(Foo)
+        MegaPatch.it(Foo.some_method, side_effect=Exception("Error!"))
+
+        with pytest.raises(Exception) as exc:
+            Foo("s").some_method()
+
+        assert str(exc.value) == "Error!"
+
+    @pytest.mark.xfail
+    def test_assigning_return_value_later_on_class_mock_reflected_in_instance(
+        self,
+    ) -> None:
+        # there's no magic that allows this to work
+        patch = MegaPatch.it(Foo)
+        patch.mock.some_method.return_value = "new val"
+
+        assert Foo("s").some_method() == "new val"
+
 
 class TestMegaPatchAutoStart:
     def test_enabled_by_default(self) -> None:


### PR DESCRIPTION
Also, add representation function, which uses `meganame`. Example: `<Foo name='()' | friendly door 3878>`

This links the class _type_ mock to the class _instance_ mock. This has been a gotcha and should now behave as one would expect. The reason for the gotcha is that when you patch something like a class, then patch a method without turning off the old patch, the object being patched ends up being <class mock>.<my method>. However, class mocks return an instance mock, which is created at patch time, and has no knowledge of this relationship.

This implementation basically walks backwards up the parent tree then finds the instance mock and links it to the class mock. Once linked, calling the mock will call the linked mock.

Addresses #43 and #65 