### PR TITLE
#13 Add fix for renamed imports

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,14 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "check all",
+            "command": "make",
+            "args": [
+                "check_all"
+            ],
+            "type": "shell",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: check_all
+
+check_all:
+	poetry run flake8 megamock tests --max-complexity=10 --max-line-length=127
+	poetry run mypy .

--- a/megamock/__init__.py
+++ b/megamock/__init__.py
@@ -1,69 +1,8 @@
-import builtins
-import inspect
-import re
-import sys
-from types import ModuleType
-
-from megamock.import_references import References
-
+from .import_machinery import start_import_mod
 from .megamocks import MegaMock
 from .megapatches import MegaPatch
 from .megas import Mega
 from .type_util import Call
-
-orig_import = builtins.__import__
-
-skip_modules = {
-    "typing",
-    "functools",
-    "asttokens",
-}
-
-
-def start_import_mod() -> None:
-    """
-    Start the import modification
-
-    This should be done as one of the first things when testing
-    """
-
-    def new_import(*args, **kwargs) -> ModuleType:
-        result = orig_import(*args, **kwargs)
-
-        module_name = args[0]
-        if (
-            module_name not in skip_modules
-            and not module_name.startswith("_")
-            and (target_module := sys.modules.get(module_name))
-            and len(args) > 3
-            and (names := args[3])
-        ):
-            stack = inspect.stack()
-            for frame in stack:
-                if frame.code_context is None:
-                    continue
-                if frame.function == "new_import":
-                    continue
-                calling_module = inspect.getmodule(frame[0])
-                if calling_module:
-                    break
-            assert calling_module
-            for k in names:
-                code_lines = frame[4]
-                if code_lines and (
-                    renamed_result := re.search(
-                        rf"\s*from \S+ import.*\W{k}\s+as\s+(\w+)", code_lines[0]
-                    )
-                ):
-                    renamed_to = renamed_result.group(1)
-                else:
-                    renamed_to = k
-                References.add_reference(target_module, calling_module, k, renamed_to)
-
-        return result
-
-    builtins.__import__ = new_import
-
 
 __all__ = [
     "Call",

--- a/megamock/import_machinery.py
+++ b/megamock/import_machinery.py
@@ -1,0 +1,89 @@
+import builtins
+import inspect
+import linecache
+import re
+import sys
+from types import ModuleType
+from typing import Callable
+
+from megamock.import_references import References
+
+orig_import = builtins.__import__
+
+skip_modules = {
+    "typing",
+    "functools",
+    "asttokens",
+}
+
+
+def _reconstruct_full_line(
+    frame: inspect.FrameInfo, getline: Callable = linecache.getline
+) -> str:
+    """
+    Pytest uses linecache.getline to rewrite assertions, so providing
+    getline as a parameter for testing purposes
+    """
+    code_lines: list[str] | None = frame.code_context
+    if code_lines:
+        if re.search(r"[\\|\(]", code_lines[0]):
+            # reconstruct the full line
+            filename = frame.filename
+            linenum = frame.lineno + 1
+
+            lines = [code_lines[0]]
+            paren_count = code_lines[0].count("(") - code_lines[0].count(")")
+            next_line = code_lines[0]
+            while paren_count > 0 or next_line.rstrip().endswith("\\"):
+                next_line = getline(filename, linenum)
+                lines.append(next_line)
+                paren_count -= next_line.count(")")
+                linenum += 1
+            return "".join(lines)
+        return code_lines[0]
+    return ""
+
+
+def start_import_mod() -> None:
+    """
+    Start the import modification
+
+    This should be done as one of the first things when testing
+    """
+
+    def new_import(*args, **kwargs) -> ModuleType:
+        result = orig_import(*args, **kwargs)
+
+        module_name = args[0]
+        if (
+            module_name not in skip_modules
+            and not module_name.startswith("_")
+            and (target_module := sys.modules.get(module_name))
+            and len(args) > 3
+            and (names := args[3])
+        ):
+            stack = inspect.stack()
+            for frame in stack:
+                if frame.code_context is None:
+                    continue
+                if frame.function == "new_import":
+                    continue
+                calling_module = inspect.getmodule(frame[0])
+                if calling_module:
+                    break
+            assert calling_module
+            full_line = _reconstruct_full_line(frame)
+            for k in names:
+                if full_line and (
+                    renamed_result := re.search(
+                        rf"\s*from \S+ import.*{k}\s+as\s+(\w+)", full_line, re.DOTALL
+                    )
+                ):
+                    renamed_to = renamed_result.group(1)
+                else:
+                    renamed_to = k
+                References.add_reference(target_module, calling_module, k, renamed_to)
+
+        return result
+
+    builtins.__import__ = new_import

--- a/megamock/import_machinery.py
+++ b/megamock/import_machinery.py
@@ -16,8 +16,6 @@ skip_modules = {
     "asttokens",
 }
 
-next_line_indicator = re.compile(r"\\|\(")
-
 
 def _reconstruct_full_line(
     frame: inspect.FrameInfo, getline: Callable = linecache.getline
@@ -35,7 +33,8 @@ def _reconstruct_full_line(
         # if this is a multiline import, reconstruct the full line
         # the absense of '(' or '\' indicates a single line import
         next_line = code_lines[0]
-        if next_line_indicator.search(next_line):
+        # note: timit gives 0.078569 for this vs 0.134779 for a compiled regex
+        if "(" in next_line or "\\" in next_line:
             filename = frame.filename
             linenum = frame.lineno + 1
 

--- a/megamock/import_references.py
+++ b/megamock/import_references.py
@@ -3,18 +3,31 @@ from types import ModuleType
 
 
 class References:
-    references: dict = defaultdict(dict)
+    # (module_path, named_as, original_name)
+    references: dict[str, dict[str, tuple]] = defaultdict(dict)
+    # (module_path, original_name)
     reverse_references: dict = defaultdict(lambda: defaultdict(set))
 
     @staticmethod
-    def add_reference(module: ModuleType, calling_module: ModuleType, key: str) -> None:
+    def add_reference(
+        module: ModuleType,
+        calling_module: ModuleType,
+        original_name: str,
+        named_as: str,
+    ) -> None:
         module_path = module.__name__
-        References.references[calling_module.__name__][key] = (module_path, key)
-        References.reverse_references[module_path][key].add(calling_module.__name__)
+        References.references[calling_module.__name__][original_name] = (
+            module_path,
+            named_as,
+            original_name,
+        )
+        References.reverse_references[module_path][original_name].add(
+            (calling_module.__name__, named_as)
+        )
 
     @staticmethod
-    def get_references(module_name: str, key: str) -> set:
-        val = References.references[module_name].get(key)
+    def get_references(module_name: str, original_name: str) -> set:
+        val = References.references[module_name].get(original_name)
         if not val:
             return set()
-        return {val[0]}
+        return {(val[0], val[1])}

--- a/megamock/import_references.py
+++ b/megamock/import_references.py
@@ -1,14 +1,26 @@
 from collections import defaultdict
 from types import ModuleType
+from typing import NamedTuple
+
+ModAndName = NamedTuple("ModAndName", [("module", str), ("name", str)])
 
 
 class References:
-    # (module_path, original_name, named_as)
-    references: dict[str, dict[str, tuple]] = defaultdict(dict)
-    # (module_path, original_name)
-    reverse_references: dict = defaultdict(lambda: defaultdict(set))
-    # renames
-    renames: dict[tuple[str, str], str] = {}
+    """
+    The References class is used as part of the import machinary and its
+    the magic that allows MegaPatch to work by simply passing things in.
+    """
+
+    # References from a calling module and the name used to the
+    # source module and the original name
+    references: dict[str, dict[str, ModAndName]] = defaultdict(dict)
+    # reverse references from the source module and the original,
+    # non-nested name, to the calling module and the name used
+    reverse_references: dict[str, dict[str, set[ModAndName]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    # renames from the calling module and the name used to the original name
+    renames: dict[ModAndName, str] = {}
 
     @staticmethod
     def add_reference(
@@ -18,27 +30,60 @@ class References:
         named_as: str,
     ) -> None:
         module_path = module.__name__
-        References.references[calling_module.__name__][named_as] = (
+        References.references[calling_module.__name__][named_as] = ModAndName(
             module_path,
             original_name,
-            # named_as,
         )
         base_original_name = original_name.split(".")[0]
         References.reverse_references[module_path][base_original_name].add(
-            (calling_module.__name__, named_as)
+            ModAndName(calling_module.__name__, named_as)
         )
         if original_name != named_as:
-            References.renames[(calling_module.__name__, named_as)] = original_name
+            References.renames[
+                ModAndName(calling_module.__name__, named_as)
+            ] = original_name
 
     @staticmethod
-    def get_references(module_name: str, original_name: str) -> set:
-        val = References.references[module_name].get(original_name)
+    def get_references(module_name: str, named_as: str) -> set[ModAndName]:
+        """
+        Given an importing module and name used, return the source module and name
+
+        A set is used, but it can't have more than one element
+        """
+        val = References.references[module_name].get(named_as)
         if not val:
             return set()
-        return {(val[0], val[1])}
+        return {val}
 
     @staticmethod
-    def get_reverse_references(module_name: str, original_name: str) -> set:
+    def get_reverse_references(module_name: str, original_name: str) -> set[ModAndName]:
+        """
+        Given a source module and original name, return the imports to it.
+        This includes logic to handle the nesting of the original name. For example,
+        Foo.bar may be referenced as OtherFoo.bar. Since "Foo.bar" isn't kept track of
+        for imports, only "Foo", the base name is extracted from original_name and then
+        the referenced name is rebuilt from the right hand side of original_name.
+
+        So for example, the reverse_references may look like this:
+            {
+                "example.module": {
+                    "Foo": {
+                        ModAndName("example.other.module", "OtherFoo")
+                    }
+                }
+            }
+
+        get_reverse_references("example.module", "Foo.bar") would return:
+            {
+                ("example.other.module", "OtherFoo.bar")
+            }
+
+        The import that got us here would look like this:
+            from example.other.module import Foo as OtherFoo
+
+        And then the MegaPatch might look like this:
+            MegaPatch.it(OtherFoo.bar, ...)
+        """
         components = original_name.split(".", 0)
         if len(components) > 1:
             base_name, right_side = components[0], [".".join(components[1:])]
@@ -46,10 +91,13 @@ class References:
             base_name = components[0]
             right_side = []
         return {
-            (x[0], ".".join([x[1]] + right_side))
+            ModAndName(x.module, ".".join([x.name] + right_side))
             for x in References.reverse_references[module_name].get(base_name, set())
         }
 
     @staticmethod
     def get_original_name(module_name: str, named_as: str) -> str:
-        return References.renames.get((module_name, named_as), named_as)
+        """
+        Given an importing module and name used, return the original name
+        """
+        return References.renames.get(ModAndName(module_name, named_as), named_as)

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -298,6 +298,9 @@ class _MegaMockMixin(Generic[T, U]):
                 )
                 return result
 
+        if key == "_spec_signature":
+            return self.__signature__
+
         if (wrapped := self._wrapped_legacy_mock) is not None:
             result = getattr(wrapped, key)
             if not isinstance(result, _MegaMockMixin) and isinstance(

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -254,10 +254,12 @@ class MegaPatch(Generic[T, U]):
             passed_in_name, thing
         )
 
-        module_path = MegaPatch._determine_module_path(thing, corrected_passed_in_name)
+        name_to_patch, module_path = MegaPatch._determine_module_path_and_name(
+            thing, passed_in_name, corrected_passed_in_name
+        )
 
         patches = MegaPatch._build_patches(
-            mocker, module_path, corrected_passed_in_name, new, kwargs
+            mocker, module_path, name_to_patch, corrected_passed_in_name, new, kwargs
         )
 
         mega_patch = MegaPatch[T, type[MegaMock | T]](
@@ -278,7 +280,8 @@ class MegaPatch(Generic[T, U]):
     def _correct_for_renamed_import(passed_in_name: str, thing: Any) -> str:
         qualname = getattr(thing, "__qualname__", None)
         if qualname is None:
-            return passed_in_name
+            module_name = MegaPatch._get_module_path_for_nonclass()
+            return References.get_original_name(module_name, passed_in_name)
         return qualname
 
     @staticmethod
@@ -347,27 +350,34 @@ class MegaPatch(Generic[T, U]):
             )
 
     @staticmethod
-    def _determine_module_path(thing: Any, passed_in_name: str) -> str:
+    def _determine_module_path_and_name(
+        thing: Any, passed_in_name: str, corrected_passed_in_name: str
+    ) -> tuple[str, str]:
         if not (module_path := getattr(thing, "__module__", None)):
             owning_class = MegaPatch._get_owning_class(passed_in_name)
             if owning_class:
-                module_path = owning_class.__module__
+                return corrected_passed_in_name, owning_class.__module__
         if module_path is None:
             module_path = MegaPatch._get_module_path_for_nonclass()
-
-        if module_path is None:
-            raise Exception(f"Unable to determine module path for: {thing!r}")
-        return module_path
+            if module_path is None:
+                raise Exception(f"Unable to determine module path for: {thing!r}")
+            return passed_in_name, module_path
+        return corrected_passed_in_name, module_path
 
     @staticmethod
     def _build_patches(
-        mocker: Any, module_path: str, passed_in_name: str, new: Any, kwargs: dict
+        mocker: Any,
+        module_path: str,
+        name_to_patch: str,
+        corrected_passed_in_name: str,
+        new: Any,
+        kwargs: dict,
     ) -> list[mock._patch]:  # type: ignore  # mypy bug?
         patches = []
         for path, named_as in (
-            References.get_references(module_path, passed_in_name)
-            | References.reverse_references[module_path][passed_in_name]
-            | {(module_path, passed_in_name)}
+            References.get_references(module_path, corrected_passed_in_name)
+            | References.get_reverse_references(module_path, corrected_passed_in_name)
+            | {(module_path, name_to_patch)}
         ):
             mock_path = f"{path}.{named_as}"
             p = mocker.patch(mock_path, new, **kwargs)

--- a/megamock/megas.py
+++ b/megamock/megas.py
@@ -90,6 +90,10 @@ class Mega:
 
         Extra calls are ignored.
         """
+        try:
+            iter(calls)
+        except TypeError:
+            raise TypeError("First argument must be an iterable of call objects")
         return self._check_mock_assertion(
             lambda: self._mm.assert_has_calls(calls, any_order)
         )

--- a/megamock/type_util.py
+++ b/megamock/type_util.py
@@ -17,3 +17,5 @@ MISSING = MISSING_TYPE()
 
 Call = _Call
 call = Call(from_kall=False)
+
+__all__ = ["MISSING", "call"]

--- a/tests/simple_app/does_rename.py
+++ b/tests/simple_app/does_rename.py
@@ -1,3 +1,7 @@
 from .foo import Foo as MyFoo
 
 foo_instance = MyFoo("something")
+
+
+def func_that_uses_foo() -> str:
+    return foo_instance.some_method()

--- a/tests/simple_app/does_rename.py
+++ b/tests/simple_app/does_rename.py
@@ -1,4 +1,6 @@
-from .foo import Foo as MyFoo
+from .foo import (
+    Foo as MyFoo
+)
 
 foo_instance = MyFoo("something")
 

--- a/tests/simple_app/does_rename.py
+++ b/tests/simple_app/does_rename.py
@@ -1,0 +1,3 @@
+from .foo import Foo as MyFoo
+
+foo_instance = MyFoo("something")

--- a/tests/test_import_machinery.py
+++ b/tests/test_import_machinery.py
@@ -36,13 +36,13 @@ class TestReconstructFullLine:
         )
 
     def test_multiline_backslash_code(self) -> None:
-        self._mock_frame.code_context = ["from foo import \\\n"]
+        self._mock_frame.code_context = ["from foo import \\\r\n"]
         self._mock_frame.filename = "a_file.py"
         self._mock_frame.lineno = 2
         getline = MegaMock.it(
             linecache.getline,
-            side_effect=["    bar,\\\n", "    baz\n", "dont be here\n"],
+            side_effect=["    bar,\\\r\n", "    baz\r\n", "dont be here\r\n"],
         )
         result = _reconstruct_full_line(self._mock_frame, getline=getline)
-        assert result == "from foo import \\\n    bar,\\\n    baz\n"
+        assert result == "from foo import \\\r\n    bar,\\\r\n    baz\r\n"
         assert Mega(getline).has_calls([call("a_file.py", 3), call("a_file.py", 4)])

--- a/tests/test_import_machinery.py
+++ b/tests/test_import_machinery.py
@@ -1,0 +1,49 @@
+import inspect
+import linecache
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+from megamock.import_machinery import _reconstruct_full_line
+from megamock.megamocks import MegaMock
+from megamock.megas import Mega
+from megamock.type_util import call
+
+
+class TestReconstructFullLine:
+    @pytest.fixture(autouse=True)
+    def setup(self) -> None:
+        self._mock_frame = MegaMock.it(inspect.FrameInfo)
+
+    def test_no_code_context(self) -> None:
+        self._mock_frame.code_context = None
+        assert _reconstruct_full_line(self._mock_frame) == ""
+
+    def test_one_line_of_code(self) -> None:
+        self._mock_frame.code_context = ["from foo import bar\n"]
+        assert _reconstruct_full_line(self._mock_frame) == "from foo import bar\n"
+
+    def test_multiline_parenthesis_code(self) -> None:
+        self._mock_frame.code_context = ["from foo import (\n"]
+        self._mock_frame.filename = "a_file.py"
+        self._mock_frame.lineno = 2
+        getline = MegaMock.it(
+            linecache.getline, side_effect=["    bar,\n", "    baz,\n", ")\n"]
+        )
+        result = _reconstruct_full_line(self._mock_frame, getline=getline)
+        assert result == "from foo import (\n    bar,\n    baz,\n)\n"
+        assert Mega(getline).has_calls(
+            [call("a_file.py", 3), call("a_file.py", 4), call("a_file.py", 5)]
+        )
+
+    def test_multiline_backslash_code(self) -> None:
+        self._mock_frame.code_context = ["from foo import \\\n"]
+        self._mock_frame.filename = "a_file.py"
+        self._mock_frame.lineno = 2
+        getline = MegaMock.it(
+            linecache.getline,
+            side_effect=["    bar,\\\n", "    baz\n", "dont be here\n"],
+        )
+        result = _reconstruct_full_line(self._mock_frame, getline=getline)
+        assert result == "from foo import \\\n    bar,\\\n    baz\n"
+        assert Mega(getline).has_calls([call("a_file.py", 3), call("a_file.py", 4)])

--- a/tests/test_import_machinery.py
+++ b/tests/test_import_machinery.py
@@ -1,6 +1,5 @@
 import inspect
 import linecache
-from unittest.mock import MagicMock, create_autospec
 
 import pytest
 

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -3,12 +3,15 @@ from unittest import mock
 import pytest
 
 from megamock import MegaPatch
-from megamock.megamocks import UseRealLogic
+from megamock.megamocks import NonCallableMegaMock, UseRealLogic
 from megamock.megapatches import MegaMock
 from megamock.megas import Mega
-from tests.simple_app import foo
+from tests.simple_app import bar as other_bar
+from tests.simple_app import foo, nested_classes
 from tests.simple_app.async_portion import SomeClassWithAsyncMethods, an_async_function
-from tests.simple_app.bar import Bar, some_context_manager, some_func
+from tests.simple_app.bar import Bar, some_context_manager
+from tests.simple_app.bar import some_func
+from tests.simple_app.bar import some_func as some_other_func
 from tests.simple_app.foo import Foo
 from tests.simple_app.foo import Foo as OtherFoo
 from tests.simple_app.foo import bar, foo_instance
@@ -97,12 +100,33 @@ class TestMegaPatchPatching:
 
         assert get_nested_class_attribute_value() == "z"
 
-    # Issue https://github.com/JamesHutchison/megamock/issues/13
-    @pytest.mark.xfail
-    def test_patch_renamed_var(self) -> None:
+    def test_patch_renamed_class_method(self) -> None:
         MegaPatch.it(OtherFoo.some_method, return_value="sm")
 
         assert Foo("s").some_method() == "sm"
+
+    def test_patch_renamed_class(self) -> None:
+        MegaPatch.it(OtherFoo)
+
+        assert isinstance(Foo("s"), NonCallableMegaMock)
+
+    def test_patch_renamed_function(self) -> None:
+        MegaPatch.it(some_other_func, return_value="r")
+
+        assert other_bar.some_func("v") == "r"
+        assert some_other_func("v") == "r"
+
+    def test_patch_renamed_nested_class(self) -> None:
+        MegaPatch.it(NestedParent.NestedChild.AnotherNestedChild.a, new="b")
+
+        assert NestedParent.NestedChild.AnotherNestedChild().a == "b"
+        assert nested_classes.NestedParent.NestedChild.AnotherNestedChild().a == "b"
+
+    def test_patch_renamed_parent_module(self) -> None:
+        MegaPatch.it(other_bar.some_func, return_value="r")
+
+        assert other_bar.some_func("v") == "r"
+        assert some_other_func("v") == "r"
 
     @pytest.mark.xfail
     def test_patch_with_real_logic(self) -> None:

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -137,12 +137,12 @@ class TestMegaPatchPatching:
         assert foo.bar == "new_val"
 
     def test_patch_that_is_renamed_in_non_test_module(self) -> None:
-        from tests.simple_app.does_rename import MyFoo
+        from tests.simple_app.does_rename import func_that_uses_foo
 
         patch = MegaPatch.it(Foo)
         patch.megainstance.some_method.return_value = "it worked"
 
-        MyFoo("s").some_method() == "it worked"
+        func_that_uses_foo() == "it worked"
 
     @pytest.mark.xfail
     def test_patch_with_real_logic(self) -> None:

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -136,6 +136,14 @@ class TestMegaPatchPatching:
         assert other_bar_constant == "new_val"
         assert foo.bar == "new_val"
 
+    def test_patch_that_is_renamed_in_non_test_module(self) -> None:
+        from tests.simple_app.does_rename import MyFoo
+
+        patch = MegaPatch.it(Foo)
+        patch.megainstance.some_method.return_value = "it worked"
+
+        MyFoo("s").some_method() == "it worked"
+
     @pytest.mark.xfail
     def test_patch_with_real_logic(self) -> None:
         # this currently fails because the object created by autospec

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -14,7 +14,9 @@ from tests.simple_app.bar import some_func
 from tests.simple_app.bar import some_func as some_other_func
 from tests.simple_app.foo import Foo
 from tests.simple_app.foo import Foo as OtherFoo
-from tests.simple_app.foo import bar, foo_instance
+from tests.simple_app.foo import bar
+from tests.simple_app.foo import bar as other_bar_constant
+from tests.simple_app.foo import foo_instance
 from tests.simple_app.helpful_manager import HelpfulManager
 from tests.simple_app.locks import SomeLock
 from tests.simple_app.nested_classes import NestedParent
@@ -127,6 +129,12 @@ class TestMegaPatchPatching:
 
         assert other_bar.some_func("v") == "r"
         assert some_other_func("v") == "r"
+
+    def test_patch_renamed_constant_primitive(self) -> None:
+        MegaPatch.it(other_bar_constant, new="new_val")
+
+        assert other_bar_constant == "new_val"
+        assert foo.bar == "new_val"
 
     @pytest.mark.xfail
     def test_patch_with_real_logic(self) -> None:

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -12,6 +12,7 @@ from tests.simple_app.async_portion import SomeClassWithAsyncMethods, an_async_f
 from tests.simple_app.bar import Bar, some_context_manager
 from tests.simple_app.bar import some_func
 from tests.simple_app.bar import some_func as some_other_func
+from tests.simple_app.does_rename import func_that_uses_foo as func_uses_foo
 from tests.simple_app.foo import Foo
 from tests.simple_app.foo import Foo as OtherFoo
 from tests.simple_app.foo import bar
@@ -20,10 +21,11 @@ from tests.simple_app.foo import foo_instance
 from tests.simple_app.helpful_manager import HelpfulManager
 from tests.simple_app.locks import SomeLock
 from tests.simple_app.nested_classes import NestedParent
+from tests.simple_app.uses_nested_classes import get_nested_class_attribute_value
 from tests.simple_app.uses_nested_classes import (
-    get_nested_class_attribute_value,
-    get_nested_class_function_value,
+    get_nested_class_attribute_value as another_nested_class_attr,
 )
+from tests.simple_app.uses_nested_classes import get_nested_class_function_value
 
 
 class TestMegaPatchPatching:
@@ -136,13 +138,25 @@ class TestMegaPatchPatching:
         assert other_bar_constant == "new_val"
         assert foo.bar == "new_val"
 
-    def test_patch_that_is_renamed_in_non_test_module(self) -> None:
-        from tests.simple_app.does_rename import func_that_uses_foo
-
+    def test_patch_that_is_renamed_in_non_test_module_1(self) -> None:
         patch = MegaPatch.it(Foo)
         patch.megainstance.some_method.return_value = "it worked"
 
-        func_that_uses_foo() == "it worked"
+        func_uses_foo() == "it worked"
+
+    def test_patch_that_is_renamed_in_non_test_module_2(self) -> None:
+        from tests.simple_app.does_rename import MyFoo
+
+        patch = MegaPatch.it(MyFoo)
+        patch.megainstance.some_method.return_value = "it worked"
+
+        func_uses_foo() == "it worked"
+
+    def test_renamed_multiline(self) -> None:
+        patch = MegaPatch.it(get_nested_class_attribute_value)
+        patch.mock.return_value = "foo"
+
+        assert another_nested_class_attr() == "foo"
 
     @pytest.mark.xfail
     def test_patch_with_real_logic(self) -> None:


### PR DESCRIPTION
This fixes renamed imports by updating the import logic to capture the `as` portion of the line of code and use that as the name rather than the name passed into `MegaPatch.it`

Basically, with the import machinery, we easily get the original name, but need to pull the new name from the line of code the import occurs on. We then record import locations by the original name and store the new name for later reference.

When doing a MegaPatch, we easily get the name used in the test but need to recover the original name. We get this from the `__qualname__` attribute that's automatically added on most things.

A bunch of complexity stems from supporting renamed constants of primitives. They don't have `__qualname__`, so the whole reference system needed to be visited to support this. Then on top of that you add complexity due to limitations in what you get "out of the box" from stack frames and imports. This required building logic to piece together multiline imports.

In fact, this is quite complex.