### PR TITLE
#14 callable return type and mock name fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,8 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.python",
-				"tamasfe.even-better-toml"
+				"tamasfe.even-better-toml",
+				"stkb.rewrap"
 			],
 			"settings": {
 				"python.defaultInterpreterPath": "/workspaces/python/.venv/python"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "python.linting.flake8Enabled": true,
     "editor.codeActionsOnSave": {
         "source.organizeImports": true
-    }
+    },
+    "rewrap.wrappingColumn": 88
 }

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -355,10 +355,6 @@ class _MegaMockMixin(Generic[T, U]):
                 else:
                     mega_result.megamock.name = f"{self.megamock.name}.{key}"
                 setattr(wrapped, key, mega_result)
-                if self._linked_mock:
-                    mega_result.__dict__["_linked_mock"] = getattr(
-                        self._linked_mock, key
-                    )
                 return mega_result
             return result
         if not self.megamock.spec and not self.megamock.wraps:
@@ -729,7 +725,6 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
             if self._linked_mock is not None:
                 # why is the mock not called as a bound method
                 return self._linked_mock(self, *args, **kwargs)
-                # return self._linked_mock(*args, **kwargs)
             result = wrapped(*args, **kwargs)
             self._validate_spec_was_callable()
             if not isinstance(result, _MegaMockMixin) and isinstance(
@@ -752,7 +747,9 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
             raise TypeError(f"{self.megamock.spec} is not callable")
 
     def _get_call_spec(self) -> Any:
-
+        """
+        Determine what the spec is for a function's return based on the annnotations
+        """
         if self.megamock.spec is None:
             return None
         annotations = self.megamock.spec.__annotations__

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -748,29 +748,8 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
             return
         if self.megamock.spec is None:
             return
-        # if self.megamock._wrapped_mock is not None:
-        #     if self.megamock.instance and not getattr(
-        #         self, "_mock_return_value_", None
-        #     ):
-        #         if not _instance_callable(self.megamock.spec):
-        #             raise TypeError(f"{self.megamock.spec} is not callable")
-        #     else:
         if not callable(self.megamock.spec):
             raise TypeError(f"{self.megamock.spec} is not callable")
-
-        # if not self.megamock.spec:
-        #     return
-        # # if spec is a type, check if the instance is callable
-        # if not hasattr(self.megamock.spec, "__call__"):
-        #     raise TypeError(f"{self.megamock.spec} is not callable")
-        # if not callable(self.megamock.spec):
-        #     raise TypeError(f"{self.megamock.spec} is not callable")
-        # # if the spec is a Union
-        # if (
-        #     typing.get_origin(self.megamock.spec) == typing.Union
-        # ):
-        #     if not any(callable(t) for t in self.megamock.spec.__args__):
-        #         raise TypeError(f"{self.megamock.spec} is not callable")
 
     def _get_call_spec(self) -> Any:
 
@@ -779,10 +758,6 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
         annotations = self.megamock.spec.__annotations__
         return_type = annotations.get("return", None)
         return create_autospec(return_type, instance=True)
-        return return_type
-        # if return_type is None:
-        #     return None
-        # if isinstance(return_type, typing.Union):
 
 
 class NonCallableMegaMock(

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -318,14 +318,6 @@ class MegaPatch(Generic[T, U]):
             return References.get_original_name(module_name, passed_in_name)
         return qualname
 
-    # @staticmethod
-    # def _maybe_correct_return_value_spec(new: Any, return_value: Any) -> None:
-    #     # Fix spec for Foo() -> instance of Foo
-    #     if isinstance(new, MegaMock):
-    #         if isinstance(return_value, _MegaMockMixin):
-    #             if return_value.megamock.spec is None:
-    #                 return_value.megamock.spec = new.megamock.spec
-
     @staticmethod
     def _maybe_assign_link(
         parent_mock: _MegaMockMixin | None, passed_in_name: str, mega_patch: MegaPatch
@@ -339,13 +331,6 @@ class MegaPatch(Generic[T, U]):
                 )._megalink_to(mega_patch.mock)
             except ValueError:
                 pass  # not a mock
-        # elif mega_patch.new_value_is_mock() and hasattr(mega_patch.mock, "megamock"):
-        #     assert passed_in_name
-        #     this_name = passed_in_name.split(".")[-1]
-        #     if this_name == passed_in_name and inspect.isclass(
-        #         mega_patch.mock.megamock.spec
-        #     ):
-        #         cast(MegaMock, mega_patch.megainstance)._megalink_to(mega_patch.mock)
 
     @staticmethod
     def _new_return_value(

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -306,8 +306,6 @@ class MegaPatch(Generic[T, U]):
 
         MegaPatch._maybe_assign_link(parent_mock, corrected_passed_in_name, mega_patch)
 
-        # MegaPatch._maybe_correct_return_value_spec(new, return_value)
-
         return mega_patch
 
     @staticmethod

--- a/tests/simple_app/foo.py
+++ b/tests/simple_app/foo.py
@@ -30,5 +30,8 @@ class Foo:
     def what_moos(self) -> str:
         return f"The {self.moo} moos"
 
+    def get_a_manager(self) -> HelpfulManager:
+        return HelpfulManager()
+
 
 foo_instance = Foo("global")

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -137,7 +137,7 @@ class TestMegaMock:
         def test_name_of_method(self) -> None:
             mega_mock = MegaMock.it(Foo)
             child_mock = mega_mock.some_method()
-            assert "name='Foo().some_method()'" in str(child_mock)
+            assert "name='Foo.some_method() -> str'" in str(child_mock)
 
         def test_name_of_mock_with_no_spec(self) -> None:
             mock = MegaMock()
@@ -168,8 +168,24 @@ class TestMegaMock:
             result = mock.NestedChild.AnotherNestedChild.z()
 
             assert (
-                "name='NestedParent().NestedChild().AnotherNestedChild().z()'"
+                "name='NestedParent.NestedChild.AnotherNestedChild.z() -> str'"
                 in str(result)
+            )
+
+        def test_cached_property(self) -> None:
+            mock = MegaMock.it(Foo)
+            assert "name='Foo.helpful_manager" in str(mock.helpful_manager)
+
+        def test_method_return_value(self) -> None:
+            mock = MegaMock.it(Foo)
+            assert "name='Foo.get_a_manager() -> HelpfulManager'" in str(
+                mock.get_a_manager()
+            )
+
+        def test_method_return_value_attribute(self) -> None:
+            mock = MegaMock.it(Foo)
+            assert "name='Foo.get_a_manager() -> HelpfulManager.a'" in str(
+                mock.get_a_manager().a
             )
 
     class TestMockingAClass:
@@ -223,12 +239,10 @@ class TestMegaMock:
 
             mock_instance()
 
-        # The return type for callable is not inspected, so a generic MegaMock
-        # is always used. To support this, the annotated return type for __call__
-        # would need to be inspected
-        # Issue https://github.com/JamesHutchison/megamock/issues/14
-        @pytest.mark.xfail
-        def test_callable_result_has_same_callable_property(self) -> None:
+        def test_callable_return_type_matches_annotations(self) -> None:
+            with pytest.raises(TypeError):
+                MegaMock.it(Foo).some_method()()
+
             mock_instance = MegaMock.it(Bar)
 
             with pytest.raises(TypeError):

--- a/tests/test_megamocks.py
+++ b/tests/test_megamocks.py
@@ -616,3 +616,22 @@ class TestMegaMock:
 
             with mega_mock as val:
                 assert val == "foo"
+
+    class TestGetCallSpec:
+        def test_when_annotations_are_missing(self) -> None:
+            mock = MegaMock.it(object())
+            assert mock._get_call_spec() is None
+
+        def test_when_return_annotation_not_provided(self) -> None:
+            def some_func(arg: str):
+                return "foo"
+
+            mock = MegaMock.it(some_func)
+            assert mock._get_call_spec() is None
+
+        def test_when_annotations_are_provided(self) -> None:
+            def some_func(arg: str) -> str:
+                return "foo"
+
+            mock = MegaMock.it(some_func)
+            assert not callable(mock._get_call_spec())

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -291,15 +291,15 @@ class TestMegaPatchReturnValue:
 
         assert Foo("s").some_method() == "value"
 
-    def test_enable_real_logic_with_casting(self) -> None:
+    def test_enable_real_logic_mega(self) -> None:
         patch = MegaPatch.it(Foo)
         Mega(patch.return_value.some_method).use_real_logic()
 
         assert Foo("s").some_method() == "value"
 
-    # see: https://github.com/JamesHutchison/megamock/issues/43
     @pytest.mark.xfail
     def test_using_actual_thing_to_enable_real_logic(self) -> None:
+        # must use the mock to assign real logic
         MegaPatch.it(Foo)
         Mega(Foo.some_method).use_real_logic()
 
@@ -497,6 +497,12 @@ class TestMegaPatchAsFunctionDecorator:
 class TestMegaPatchNames:
     def test_megapatch_class(self) -> None:
         patch = MegaPatch.it(Foo)
+
+        assert "name='Foo'" in str(patch.mock)
+
+    def test_megapatch_class_instance(self) -> None:
+        patch = MegaPatch.it(Foo)
+
         assert "name='Foo()'" in str(patch.return_value)
 
     @pytest.mark.xfail

--- a/tests/test_megapatches.py
+++ b/tests/test_megapatches.py
@@ -297,6 +297,7 @@ class TestMegaPatchReturnValue:
 
         assert Foo("s").some_method() == "value"
 
+    # https://github.com/JamesHutchison/megamock/issues/75
     @pytest.mark.xfail
     def test_using_actual_thing_to_enable_real_logic(self) -> None:
         # must use the mock to assign real logic


### PR DESCRIPTION
This aligns the callability of return types with the type itself. The type annotations determine whether the returned type is callable or not.

This also fixes a few issues with the mock names that were discovered in the process of writing this.

One of the expect fail tests should be passing by now. https://github.com/JamesHutchison/megamock/issues/75 was created to represent fixing it.

This addresses #14 

There's a notable complexity introduced:

`generate_autospec` already properly checks callability, but it only works for the item being spec'ed. Child mocks are still callable. This adds logic to enforce the callability of child mocks and also assign a spec to them. The spec is a mock object based on the annotated type. If annotations are missing, then no checks are made.