### PR TITLE
#85 Use `get_type_hints` and add gitlens and gitgraph to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,9 @@
 			"extensions": [
 				"ms-python.python",
 				"tamasfe.even-better-toml",
-				"stkb.rewrap"
+				"stkb.rewrap",
+				"mhutchie.git-graph",
+				"eamodio.gitlens"
 			],
 			"settings": {
 				"python.defaultInterpreterPath": "/workspaces/python/.venv/python"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 .dmypy.json
 dist
+.mypy_cache
+.pytest_cache


### PR DESCRIPTION
As per the ticket, using `get_type_hints` here should ensure the behavior is consistent between `from __future__ import annotations` and without, without adding extra logic for both cases.

In the process of making this, noticed gitlens and gitgraph were missing from the devcontainer config so added them.

Since this shouldn't functionally change anything, there's no need to push a new version.
Also, this introduces the risk of reduced performance, although running tests there was no obvious slowdown. Since this is the attribute access logic, this doesn't affect the import performance.