### PR TITLE
Skip modules without packages

### DIFF
--- a/megamock/import_references.py
+++ b/megamock/import_references.py
@@ -33,6 +33,15 @@ class References:
         if not calling_module.__package__:
             # this can happen if using megamock + pytest hot reloader
             return
+        References._add_reference(module, calling_module, original_name, named_as)
+
+    @staticmethod
+    def _add_reference(
+        module: ModuleType,
+        calling_module: ModuleType,
+        original_name: str,
+        named_as: str,
+    ) -> None:
         module_path = module.__name__
         References.references[calling_module.__name__][named_as] = ModAndName(
             module_path,

--- a/megamock/import_references.py
+++ b/megamock/import_references.py
@@ -29,6 +29,10 @@ class References:
         original_name: str,
         named_as: str,
     ) -> None:
+        # do not bother with bad modules. Example: conftest from pytest
+        if not calling_module.__package__:
+            # this can happen if using megamock + pytest hot reloader
+            return
         module_path = module.__name__
         References.references[calling_module.__name__][named_as] = ModAndName(
             module_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "megamock"
-version = "0.1.0-beta.3"
+version = "0.1.0-beta.4"
 description = "Mega mocking capabilities - stop using dot-notated paths!"
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/tests/unit/test_import_references.py
+++ b/tests/unit/test_import_references.py
@@ -1,0 +1,16 @@
+from megamock.import_references import References
+from megamock.megamocks import MegaMock
+from megamock.megapatches import MegaPatch
+from megamock.megas import Mega
+
+
+class TestReferences:
+    class TestAddReference:
+        def test_when_package_is_missing_do_not_add(self) -> None:
+            patch = MegaPatch.it(References._add_reference)
+
+            calling_module = MegaMock()
+            calling_module.__package__ = ""
+            References.add_reference(MegaMock(), calling_module, "orig", "named_as")
+
+            assert Mega(patch.mock).not_called()


### PR DESCRIPTION
This was encountered during a megamock / python hot reloader integration