### PR TITLE
Use different pytest hook

### DIFF
--- a/megamock/plugins/pytest.py
+++ b/megamock/plugins/pytest.py
@@ -4,7 +4,7 @@ import pytest
 from megamock.megapatches import MegaPatch
 
 
-def pytest_sessionstart(*args, **kwargs) -> None:
+def pytest_load_initial_conftests(*args, **kwargs) -> None:
     import megamock
 
     megamock.start_import_mod()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "megamock"
-version = "0.1.0-beta.6"
+version = "0.1.0-beta.7"
 description = "Mega mocking capabilities - stop using dot-notated paths!"
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,9 @@
+import pytest
+from megamock.megapatches import MegaPatch
+
+from tests.unit.simple_app.for_autouse_1 import modified_function
+
+
 class SomeClass:
     a: str | None
 
@@ -8,3 +14,8 @@ class SomeClass:
         return "b"
 
     c = 1
+
+
+@pytest.fixture(autouse=True)
+def some_autouse_fixture() -> None:
+    MegaPatch.it(modified_function, return_value="modified")

--- a/tests/unit/simple_app/for_autouse_1.py
+++ b/tests/unit/simple_app/for_autouse_1.py
@@ -1,0 +1,5 @@
+from tests.unit.simple_app.for_autouse_2 import modified_function
+
+
+def get_value() -> str:
+    return modified_function()

--- a/tests/unit/simple_app/for_autouse_2.py
+++ b/tests/unit/simple_app/for_autouse_2.py
@@ -1,0 +1,2 @@
+def modified_function() -> str:
+    return "original"

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,0 +1,6 @@
+from tests.unit.simple_app.for_autouse_1 import get_value
+
+
+class TestPytestPlugin:
+    def test_import_invoked_early_enough(self) -> None:
+        assert get_value() == "modified"


### PR DESCRIPTION
This fixes a bug where in some circumstances the import modifications weren't recorded in the import machinery because pytest had already imported the relevant module prior to starting the session.