### PR TITLE
Fix megamock it type hint

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,7 +9,7 @@ foo.some_method(wrong, args)  # raises error
 ```
 
 ```python
-FooMock = MegaMock.it(Foo, instance=False)  # FooMock is a type
+FooMock = MegaMock.that(Foo)  # FooMock is a type
 ```
 
 ## Patch objects by simply passing them in. Patches start automatically
@@ -48,7 +48,7 @@ Mega(my_mock.some_method).use_real_logic()
 addopts = "-p megamock.plugins.pytest"
 ```
 
-## Assert using the assert statement instead of assert functions
+## For pytest, assert using the assert statement instead of assert functions
 
 ```python
 assert Mega(my_mock.some_method).called_with(1, 2, 3)

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ function prior to importing any production or test code. You will also want it s
 
 **Core Classes**
 
-`MegaMock` - the primary class for a mocked object. This is similar to `MagicMock`. Use `MegaMock.it(MyObject)` to make `MyObject` the [spec](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.create_autospec).
+`MegaMock` - the primary class for a mocked object. This is similar to `MagicMock`. To create a mock instance of a class, use `MegaMock.it(MyClass)` to make `MyClass` the [spec](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.create_autospec). To create mock instances of instantiated objects, functions, classes (the type), etc, use `MegaMock.this(some_object)`.
 
 `MegaPatch` - the class for patching. This is similar to `patch`. Use `MegaPath.it(MyObject)` to replace new instances of the `MyObject` class.
 
-`Mega` - helper class for accessing mock attributes without having to memorize the due to lost type inference. Use `Mega(some_megamock)`.
+`Mega` - helper class for accessing mock attributes without having to memorize them due to lost type inference. Use `Mega(some_megamock)`.
 Note that the `assert_` methods, such as `assert_called_once`, is now `called_once` and returns a boolean. The assertion error
-is stored in `Mega.last_assertion_error`.
+is stored in `Mega.last_assertion_error`. This is typically for doing asserts against mocked functions and methods.
 
 --------------------
 
@@ -169,7 +169,7 @@ def test_something(...):
     ...
 ```
 
-`MegaMock` objects have the same attributes as regular `MagicMock`s plus `megamock` and `megainstance`
+`MegaMock` objects have the same attributes as regular `MagicMock`s plus `megamock` and `megainstance`.
 For example, `my_mega_mock.megamock.spy` is the object being spied, if set. `my_class_mock.megainstance` is the instance returned when the class is instantiated.
 
 The [guidance document](GUIDANCE.md) is available to provide in-depth information on using mocking and MegaMock. Continuing reading to
@@ -195,14 +195,15 @@ mock_instance = MegaMock.it(MyClass)
 Creating a mock class itself:
 
 ```python
-mock_class = MegaMock.it(MyClass, instance=False)
+mock_class = MegaMock.this(MyClass)
+func_that_wants_a_type(mock_class)
 ```
 
 Spying an object:
 
 ```python
 my_thing = MyClass()
-spied_class = MegaMock(spy=my_thing)
+spied_class = MegaMock.this(spy=my_thing)
 
 # ... do stuff with spied_class...
 

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -311,7 +311,7 @@ class _MegaMockMixin(Generic[T, U]):
             (mock.MagicMock, mock.Mock),  # callable mocks
         ) or not isclass(self.megamock.spec):
             raise Exception("The megainstance property was intended for class mocks")
-        return cast(U, self.return_value)  # type: ignore
+        return cast(U, self.return_value)
 
     @property
     def _mock_return_value(self) -> Any:
@@ -516,6 +516,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
     Use: MegaMock.it(MySpecClass)
     """
 
+    # Passthrough logic for quickly casting to a MegaMock
     def __new__(cls, _existing: _MegaMockMixin | Any = None, *args, **kwargs):
         if hasattr(_existing, "megamock"):
             return cast(MegaMock[T, U], _existing)
@@ -820,7 +821,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
                 wraps=wraps,
                 _parent_mega_mock=parent_megamock,
             )
-        return MegaMock.this(  # using class because it doesn't require T is a type
+        return MegaMock.this(
             _wraps_mock=mock_obj,
             spec=spec,
             wraps=wraps,

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -15,6 +15,7 @@ from typing import (
     Generic,
     Literal,
     TypeVar,
+    Union,
     cast,
     get_type_hints,
     overload,
@@ -199,7 +200,7 @@ class _MegaMockMixin(Generic[T, U]):
         :param instance: If True, the mock will be an instance of the spec. If False,
             the mock will be a class. By default this is True. This must be omitted or
             False for the AsyncMock
-        :param side_effect: The side effect to use for the mock. Exceptoins are raised,
+        :param side_effect: The side effect to use for the mock. Exceptions are raised,
             fuctions are called, and iterables are returned in order in subsequent calls
         :param return_value: The return value to use for the mock.
         :param _wraps_mock: the wrapped mock, for internal use
@@ -310,7 +311,7 @@ class _MegaMockMixin(Generic[T, U]):
             (mock.MagicMock, mock.Mock),  # callable mocks
         ) or not isclass(self.megamock.spec):
             raise Exception("The megainstance property was intended for class mocks")
-        return cast(U, self.return_value)
+        return cast(U, self.return_value)  # type: ignore
 
     @property
     def _mock_return_value(self) -> Any:
@@ -515,15 +516,29 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
     Use: MegaMock.it(MySpecClass)
     """
 
+    def __new__(cls, _existing: _MegaMockMixin | Any = None, *args, **kwargs):
+        if hasattr(_existing, "megamock"):
+            return cast(MegaMock[T, U], _existing)
+        return super().__new__(cls, *args, **kwargs)
+
     # Types MegaMock()
     @overload
     def __init__(self: MegaMock[None, None]) -> None:
+        ...
+
+    # Types MegaMock(existing_megamock)
+    @overload
+    def __init__(
+        self: MegaMock[T, U],
+        _existing: _MegaMockMixin[T, U] | Union[_MegaMockMixin[T, U], T],
+    ) -> None:
         ...
 
     # types MegaMock(spec=SomeClass, instance=False, ...)
     @overload
     def __init__(
         self: _MegaMockMixin[T, U],
+        _existing: None = None,
         *,
         spec: type[T],
         instance: Literal[False] = False,
@@ -548,6 +563,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
     @overload
     def __init__(
         self: _MegaMockMixin[T, U],
+        _existing: None = None,
         *,
         spec: T,
         _wraps_mock: (
@@ -572,6 +588,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
     @overload
     def __init__(
         self: MegaMock[T, T],
+        _existing: None = None,
         *,
         _wraps_mock: (
             mock.Mock
@@ -593,6 +610,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
 
     def __init__(
         self,
+        _existing: Any | None = None,
         *,
         spec: T | type[T] | None = None,
         wraps: T | None = None,
@@ -623,13 +641,17 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
         :param instance: If True, the mock will be an instance of the spec. If False,
             the mock will be a class. By default this is True. This must be omitted or
             False for the AsyncMock
-        :param side_effect: The side effect to use for the mock. Exceptoins are raised,
+        :param side_effect: The side effect to use for the mock. Exceptions are raised,
             fuctions are called, and iterables are returned in order in subsequent calls
         :param return_value: The return value to use for the mock.
         :param _wraps_mock: the wrapped mock, for internal use
         :param _parent_mega_mock: The parent MegaMock, for internal use
         """
-        return super().__init__(
+        if _existing:
+            if hasattr(_existing, "megamock"):
+                return
+            raise Exception("Use MegaMock.it(...) for new mocks, not MegaMock")
+        super().__init__(
             spec,
             wraps=wraps,
             spy=spy,
@@ -643,14 +665,20 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
             **kwargs,
         )
 
+    ##################
+    # DRAGON WARNING
+    ##################
+    # Do NOT type annotate the return type of MegaMock.it and MegaMock.this
+    # Doing this will cause mypy to complain about the union of MegaMock and the spec
+    # because MyPy / python do not (yet) have a true union / merge type.
+    # The hack used here circumvents the attr-check error you would get attempting to
+    # access any attributes of MegaMock
+
     @staticmethod
     def it(
-        spec: T | None = None,
+        spec: type[T] | None = None,
         *,
-        wraps: T | None = None,
-        spy: T | None = None,
         spec_set: bool = True,
-        instance: bool | None = None,
         side_effect: Any = None,
         return_value: Any = MISSING,
         _wraps_mock: (
@@ -664,6 +692,83 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
         # warning: kwargs to MagicMock may not work correctly! Use at your own risk!
         **kwargs,
     ):
+        """
+        MegaMock a class instance.
+
+        Use `it` for creating mock instances of classes. Use `this` for everything else.
+
+        Note that spec_set defaults to True, which means attempts to set
+        an attribute that doesn't exist will result in an error.
+
+        The recommended way to use classes with MegaMock is to define
+        the type annotations in the class. It does not know what is set
+        inside the __init__ function.
+
+        If you do not own the class and cannot change it, set spec_set to False.
+
+        :param spec: The class to create a mock instance of
+        :param spec_set: If True, only attributes in the spec will be allowed. Assigning
+            attributes not part of the spec will result in a AttributeError
+        :param side_effect: The side effect to use for the mock.
+        :param return_value: The return value to use for the mock. Since this is for
+            a class instance, it would be setting the return value of __call__
+        """
+
+        # hack to get static type inference to think this is a true union
+        # of the two classes
+        def helper(obj) -> type[MegaMock[T, MegaMock | T] | T]:
+            return cast(type[MegaMock | T], lambda: obj)
+
+        return helper(
+            MegaMock(
+                spec=spec,
+                spec_set=spec_set,
+                instance=True,
+                side_effect=side_effect,
+                return_value=return_value,
+                _wraps_mock=_wraps_mock,
+                _parent_mega_mock=_parent_mega_mock,
+                _merged_type=type(MegaMock | spec.__class__),
+                **kwargs,
+            ),
+        )()
+
+    @staticmethod
+    def this(
+        spec: T | None = None,
+        *,
+        wraps: T | None = None,
+        spy: T | None = None,
+        spec_set: bool = True,
+        side_effect: Any = None,
+        return_value: Any = MISSING,
+        _wraps_mock: (
+            mock.Mock
+            | mock.MagicMock
+            | mock.NonCallableMock
+            | mock.NonCallableMagicMock
+            | None
+        ) = None,
+        _parent_mega_mock: _MegaMockMixin | None = None,
+        # warning: kwargs to MagicMock may not work correctly! Use at your own risk!
+        **kwargs,
+    ):
+        """
+        MegaMock something.
+
+        Use `it` for creating mock instances of classes. Use `this` for everything else.
+
+        :param wraps: An object to wrap, this is included for legacy support. Prefer spy
+        :param spy: An object to spy on. The mock will maintain the real behavior of the
+            object, but will also track attribute access and assignments
+        :param spec_set: If True, only attributes in the spec will be allowed. Assigning
+            attributes not part of the spec will result in a AttributeError
+        :param side_effect: The side effect to use for the mock. Exceptions are raised,
+            fuctions are called, and iterables are returned in order in subsequent
+            calls
+        :param return_value: The return value to use for the mock.
+        """
+
         # hack to get static type inference to think this is a true union
         # of the two classes
         def helper(obj) -> type[MegaMock[T, MegaMock | T] | T]:
@@ -675,7 +780,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
                 wraps=wraps,
                 spy=spy,
                 spec_set=spec_set,
-                instance=instance,
+                instance=False,
                 side_effect=side_effect,
                 return_value=return_value,
                 _wraps_mock=_wraps_mock,
@@ -684,6 +789,10 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
                 **kwargs,
             ),
         )()
+
+    ######################
+    # END DRAGON WARNING
+    ######################
 
     @staticmethod
     def from_legacy_mock(
@@ -711,7 +820,7 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
                 wraps=wraps,
                 _parent_mega_mock=parent_megamock,
             )
-        return MegaMock.it(
+        return MegaMock.this(  # using class because it doesn't require T is a type
             _wraps_mock=mock_obj,
             spec=spec,
             wraps=wraps,
@@ -796,6 +905,9 @@ class MegaMock(_MegaMockMixin[T, U], mock.MagicMock, Generic[T, U]):
         if return_type is None:
             return None
         return create_autospec(return_type, instance=True)
+
+
+MegaMockType = type[MegaMock[T, MegaMock | T] | T]
 
 
 class NonCallableMegaMock(

--- a/tests/manual/megamock_type_hints.py
+++ b/tests/manual/megamock_type_hints.py
@@ -1,0 +1,18 @@
+from megamock.megamocks import MegaMock
+from tests.simple_app.foo import Foo
+
+
+def megamock_type_hints():
+    """
+    This is a manual test. Check the type hints look correct in your IDE
+
+    There's no expectation to run this function
+    """
+    no_instance_param = MegaMock.it(Foo)  # type hint should NOT have type[Foo] in it
+    no_instance_param.takes_args("arg1", "arg2")  # should NOT show self as an argument
+
+    # mock class object type hints
+    # should have type[Foo]
+    instance_is_false = MegaMock.this(Foo)
+    # should have self argument
+    instance_is_false.takes_args(no_instance_param, "arg1", "arg2")

--- a/tests/simple_app/foo.py
+++ b/tests/simple_app/foo.py
@@ -33,5 +33,8 @@ class Foo:
     def get_a_manager(self) -> HelpfulManager:
         return HelpfulManager()
 
+    def takes_args(self, arg1: str, arg2: str) -> tuple[str, str]:
+        return (arg1, arg2)
+
 
 foo_instance = Foo("global")

--- a/tests/unit/simple_app/nested_classes.py
+++ b/tests/unit/simple_app/nested_classes.py
@@ -5,3 +5,7 @@ class NestedParent:
 
             def z(self) -> str:
                 return "z"
+
+            @staticmethod
+            def static_z() -> str:
+                return "static_z"

--- a/tests/unit/test_import_machinery.py
+++ b/tests/unit/test_import_machinery.py
@@ -28,7 +28,7 @@ class TestReconstructFullLine:
     def test_multiline_parenthesis_code(self) -> None:
         self._code_lines_patch.mock.return_value = ["from foo import (\n"], 2
         self._mock_frame.f_code.co_filename = "a_file.py"
-        getline = MegaMock.it(
+        getline = MegaMock.this(
             linecache.getline, side_effect=["    bar,\n", "    baz,\n", ")\n"]
         )
         result = _reconstruct_full_line(self._mock_frame, getline=getline)
@@ -40,7 +40,7 @@ class TestReconstructFullLine:
     def test_multiline_backslash_code(self) -> None:
         self._code_lines_patch.mock.return_value = ["from foo import \\\r\n"], 2
         self._mock_frame.f_code.co_filename = "a_file.py"
-        getline = MegaMock.it(
+        getline = MegaMock.this(
             linecache.getline,
             side_effect=["    bar,\\\r\n", "    baz\r\n", "dont be here\r\n"],
         )

--- a/tests/unit/test_megamocks.py
+++ b/tests/unit/test_megamocks.py
@@ -465,7 +465,7 @@ class TestMegaMock:
             # check preconditions
             assert isinstance(mega_mock.some_method(), MegaMock)
 
-            MegaMock(mega_mock.some_method).return_value = UseRealLogic
+            mega_mock.some_method.return_value = UseRealLogic
 
             assert mega_mock.some_method() == "value"
 

--- a/tests/unit/test_megamocks.py
+++ b/tests/unit/test_megamocks.py
@@ -63,7 +63,7 @@ class TestMegaMock:
         def some_func(val: str) -> str:
             return val
 
-        mega_mock = MegaMock.it(some_func, return_value="foo")
+        mega_mock = MegaMock.this(some_func, return_value="foo")
         assert mega_mock("input val") == "foo"
 
         with pytest.raises(TypeError):
@@ -84,23 +84,23 @@ class TestMegaMock:
         async def some_func() -> str:
             return "s"
 
-        mega_mock = MegaMock.it(some_func)
+        mega_mock = MegaMock.this(some_func)
         assert asyncio.iscoroutinefunction(mega_mock) is True
         assert inspect.isawaitable(mega_mock()) is True
 
     def test_assigning_return_value(self) -> None:
-        mega_mock = MegaMock.it(Foo)
+        mega_mock = MegaMock.this(Foo)
         mega_mock.some_method.return_value = "foo"
 
         assert mega_mock.some_method() == "foo"
 
     def test_allows_for_setting_different_type(self) -> None:
-        mega_mock: Foo = MegaMock.it(Foo)  # mypy should not care
+        mega_mock: Foo = MegaMock.this(Foo)  # mypy should not care
 
         assert mega_mock.z
 
     def test_assert_called_once_with(self) -> None:
-        mega_mock = MegaMock.it(Foo, instance=False)
+        mega_mock = MegaMock.this(Foo)
 
         mega_mock("s")
 
@@ -132,11 +132,11 @@ class TestMegaMock:
 
     class TestGenerateMockName:
         def test_name_of_class(self) -> None:
-            mega_mock = MegaMock.it(Foo)
+            mega_mock = MegaMock.this(Foo)
             assert "name='Foo'" in str(mega_mock)
 
         def test_name_of_method(self) -> None:
-            mega_mock = MegaMock.it(Foo)
+            mega_mock = MegaMock.this(Foo)
             child_mock = mega_mock.some_method()
             assert "name='Foo.some_method() -> str'" in str(child_mock)
 
@@ -165,33 +165,33 @@ class TestMegaMock:
             )
 
         def test_nested_objects(self) -> None:
-            mock = MegaMock.it(NestedParent)
-            result = mock.NestedChild.AnotherNestedChild.z()
+            mock = MegaMock.this(NestedParent)
+            result = mock.NestedChild.AnotherNestedChild.static_z()
 
             assert (
-                "name='NestedParent.NestedChild.AnotherNestedChild.z() -> str'"
+                "name='NestedParent.NestedChild.AnotherNestedChild.static_z() -> str'"
                 in str(result)
             )
 
         def test_cached_property(self) -> None:
-            mock = MegaMock.it(Foo)
+            mock = MegaMock.this(Foo)
             assert "name='Foo.helpful_manager" in str(mock.helpful_manager)
 
         def test_method_return_value(self) -> None:
-            mock = MegaMock.it(Foo)
+            mock = MegaMock.this(Foo)
             assert "name='Foo.get_a_manager() -> HelpfulManager'" in str(
                 mock.get_a_manager()
             )
 
         def test_method_return_value_attribute(self) -> None:
-            mock = MegaMock.it(Foo)
+            mock = MegaMock.this(Foo)
             assert "name='Foo.get_a_manager() -> HelpfulManager.a'" in str(
                 mock.get_a_manager().a
             )
 
     class TestMockingAClass:
         def test_classes_default_to_instance(self) -> None:
-            mock_instance: SomeClass = MegaMock.it(SomeClass)
+            mock_instance: SomeClass = MegaMock.this(SomeClass)
 
             with pytest.raises(AttributeError):
                 mock_instance.does_not_exist  # type: ignore
@@ -199,23 +199,23 @@ class TestMegaMock:
             mock_instance.b()
 
         def test_can_create_mock_for_class_itself(self) -> None:
-            mock_class: type[SomeClass] = MegaMock.it(SomeClass, instance=False)
+            mock_class: type[SomeClass] = MegaMock.this(SomeClass)
 
             mock_class.c
 
         def test_mock_classes_do_not_have_undefined_attributes(self) -> None:
-            mock_class: type[SomeClass] = MegaMock.it(SomeClass, instance=False)
+            mock_class: type[SomeClass] = MegaMock.this(SomeClass)
 
             with pytest.raises(AttributeError):
                 mock_class.a
 
         def test_delimited_attributes_are_allowed_if_spec_set_is_true(self) -> None:
-            mock_instance: SomeClass = MegaMock.it(SomeClass, spec_set=True)
+            mock_instance: SomeClass = MegaMock.this(SomeClass, spec_set=True)
 
             mock_instance.a = "some str"
 
         def test_spec_set_with_annotations_enforces_type(self) -> None:
-            mock_instance: SomeClass = MegaMock.it(SomeClass, spec_set=True)
+            mock_instance: SomeClass = MegaMock.this(SomeClass, spec_set=True)
 
             with pytest.raises(TypeError) as exc:
                 mock_instance.a = 12345  # type: ignore
@@ -223,34 +223,32 @@ class TestMegaMock:
             assert str(exc.value) == "12345 is not an instance of str | None"
 
         def test_spec_set_with_annotations_allows_mock_objects(self) -> None:
-            mock_instance: SomeClass = MegaMock.it(SomeClass, spec_set=True)
+            mock_instance: SomeClass = MegaMock.this(SomeClass, spec_set=True)
 
-            mock_instance.a = MegaMock.it(str)
+            mock_instance.a = MegaMock.this(str)
 
         def test_spec_set_defaults_to_true(self) -> None:
-            mock_instance: SomeClass = MegaMock.it(
-                SomeClass, spec_set=True, instance=True
-            )
+            mock_instance: SomeClass = MegaMock.this(SomeClass, spec_set=True)
 
             with pytest.raises(AttributeError):
                 mock_instance.does_not_exist = 5  # type: ignore
 
         def test_callable_classes_are_callable(self) -> None:
-            mock_instance = MegaMock.it(Bar)
+            mock_instance = MegaMock.this(Bar)
 
             mock_instance()
 
         def test_callable_return_type_matches_annotations(self) -> None:
             with pytest.raises(TypeError):
-                MegaMock.it(Foo).some_method()()
+                MegaMock.this(Foo).some_method()()
 
-            mock_instance = MegaMock.it(Bar)
+            mock_instance = MegaMock.this(Bar)
 
             with pytest.raises(TypeError):
                 mock_instance()()
 
         def test_noncallable_classes_are_not_callable(self) -> None:
-            mock_instance = MegaMock.it(Foo)
+            mock_instance = MegaMock.this(Foo)
 
             with pytest.raises(TypeError):
                 mock_instance()
@@ -336,14 +334,14 @@ class TestMegaMock:
     class TestWraps:
         def test_wraps_object(self) -> None:
             obj = Foo("s")
-            mega_mock = MegaMock.it(wraps=obj)
+            mega_mock = MegaMock.this(wraps=obj)
 
             assert mega_mock.some_method() == "value"
-            assert len(mega_mock.some_method.call_args_list) == 1
+            assert len(cast(MegaMock, mega_mock.some_method).call_args_list) == 1
 
         def test_wraps_has_same_warts_as_magicmock(self) -> None:
             obj = Foo("s")
-            mega_mock = MegaMock.it(wraps=obj)
+            mega_mock = MegaMock.this(wraps=obj)
 
             assert isinstance(mega_mock.s, MegaMock)
 
@@ -351,11 +349,11 @@ class TestMegaMock:
         @pytest.fixture(autouse=True)
         def setup(self) -> None:
             self.obj = Foo("s")
-            self.mega_mock = MegaMock.it(spy=self.obj)
+            self.mega_mock = MegaMock.this(spy=self.obj)
 
         def test_equivalent_to_wraps_for_methods(self) -> None:
             assert self.mega_mock.some_method() == "value"
-            assert len(self.mega_mock.some_method.call_args_list) == 1
+            assert len(cast(MegaMock, self.mega_mock.some_method).call_args_list) == 1
 
         def test_supports_properties(self) -> None:
             self.mega_mock._s = "str"
@@ -462,38 +460,38 @@ class TestMegaMock:
 
     class TestUseRealLogic:
         def test_will_use_real_method_values(self) -> None:
-            mega_mock = MegaMock.it(Foo("s"), spec_set=False)
+            mega_mock = MegaMock.this(Foo("s"), spec_set=False)
 
             # check preconditions
             assert isinstance(mega_mock.some_method(), MegaMock)
 
-            mega_mock.some_method.return_value = UseRealLogic
+            MegaMock(mega_mock.some_method).return_value = UseRealLogic
 
             assert mega_mock.some_method() == "value"
 
         def test_real_logic_uses_mock_object_values(self) -> None:
-            mega_mock = MegaMock.it(Foo("s"))
+            mega_mock = MegaMock.this(Foo("s"))
             mega_mock.moo = "fox"
-            mega_mock.what_moos.return_value = UseRealLogic
+            MegaMock(mega_mock.what_moos).return_value = UseRealLogic
 
             assert mega_mock.what_moos() == "The fox moos"
 
         def test_real_logic_with_class_instance_shortcut(self) -> None:
-            mega_mock = MegaMock.it(Foo)
+            mega_mock = MegaMock.this(Foo)
             mega_mock.moo = "fox"
-            mega_mock.what_moos.return_value = UseRealLogic
+            MegaMock(mega_mock.what_moos).return_value = UseRealLogic
 
             assert mega_mock.what_moos() == "The fox moos"
 
         def test_function_call_on_mock_object(self) -> None:
-            mega_mock = MegaMock.it(Foo("s"))
+            mega_mock = MegaMock.this(Foo("s"))
             mega_mock.moo = "fox"
             Mega(mega_mock.what_moos).use_real_logic()
 
             assert mega_mock.what_moos() == "The fox moos"
 
         def test_function_call_on_cast_object(self) -> None:
-            mega_mock = MegaMock.it(Foo("s"))
+            mega_mock = MegaMock.this(Foo("s"))
             mega_mock.moo = "fox"
             Mega(mega_mock.what_moos).use_real_logic()
 
@@ -501,13 +499,13 @@ class TestMegaMock:
 
     class TestMegaCast:
         def test_cast_types_to_the_spec_with_type(self) -> None:
-            mega_mock = MegaMock.it(Foo)
+            mega_mock = MegaMock.this(Foo)
             mega_mock.z = "z"
 
             assert mega_mock.z == "z"
 
         def test_cast_types_to_the_spec_with_instance(self) -> None:
-            mega_mock = MegaMock.it(Foo("s"))
+            mega_mock = MegaMock.this(Foo("s"))
             mega_mock.z = "z"
 
             assert mega_mock.z == "z"
@@ -516,14 +514,15 @@ class TestMegaMock:
             def some_func(val: str) -> str:
                 return val
 
-            mega_mock = MegaMock.it(some_func)
+            mega_mock = MegaMock.this(some_func)
             mega_mock.__module__  # should have no mypy errors
 
     class TestMegaInstance:
         def test_using_class(self) -> None:
-            mega_mock = MegaMock.it(Foo, instance=False)
+            mega_mock = MegaMock.this(Foo)
 
-            mega_mock.megainstance.s  # should have no mypy errors
+            megainstance = mega_mock.megainstance
+            megainstance.s  # should have no mypy errors
             mega_mock.megainstance.moo = "fox"
 
             # check preconditions
@@ -532,7 +531,7 @@ class TestMegaMock:
             mega_mock.megainstance is Foo("s")
 
         def test_errors_if_not_a_class(self) -> None:
-            mega_mock = MegaMock.it(Foo, instance=True)
+            mega_mock = MegaMock.it(Foo)
 
             with pytest.raises(Exception) as exc:
                 mega_mock.megainstance
@@ -543,7 +542,7 @@ class TestMegaMock:
             )
 
         def test_calling_method_from_mega_instance(self) -> None:
-            mega_mock = MegaMock.it(Foo, instance=False)
+            mega_mock = MegaMock.this(Foo)
 
             mega_mock.megainstance.some_method()
 
@@ -576,7 +575,7 @@ class TestMegaMock:
             assert self.after is True
 
         def test_mocking_context_manager(self) -> None:
-            mega_mock = MegaMock.it(self.context_manager)
+            mega_mock = MegaMock.this(self.context_manager)
             mega_mock.return_value.return_value = "mocked"
 
             with mega_mock() as val:
@@ -586,7 +585,7 @@ class TestMegaMock:
             assert self.after is False
 
         def test_use_real_logic(self) -> None:
-            mega_mock = MegaMock.it(self.context_manager())
+            mega_mock = MegaMock.this(self.context_manager())
 
             Mega(mega_mock).use_real_logic()
 
@@ -596,7 +595,7 @@ class TestMegaMock:
             assert self.after is True
 
         def test_attempting_to_use_non_contextmanager(self) -> None:
-            mega_mock = MegaMock.it(Foo)
+            mega_mock = MegaMock.this(Foo)
 
             with pytest.raises(TypeError) as exc:
                 with mega_mock:
@@ -612,37 +611,37 @@ class TestMegaMock:
                 pass
 
         def test_spy_supports_context_manager(self) -> None:
-            mega_mock = MegaMock.it(spy=self.context_manager())
+            mega_mock = MegaMock.this(spy=self.context_manager())
 
             with mega_mock as val:
                 assert val == "foo"
 
     class TestGetCallSpec:
         def test_when_annotations_are_missing(self) -> None:
-            mock = MegaMock.it(object())
+            mock = MegaMock.this(object())
             assert mock._get_call_spec() is None
 
         def test_when_return_annotation_not_provided(self) -> None:
             def some_func(arg: str):
                 return "foo"
 
-            mock = MegaMock.it(some_func)
+            mock = MegaMock.this(some_func)
             assert mock._get_call_spec() is None
 
         def test_when_annotations_are_provided(self) -> None:
             def some_func(arg: str) -> str:
                 return "foo"
 
-            mock = MegaMock.it(some_func)
+            mock = MegaMock.this(some_func)
             assert not callable(mock._get_call_spec())
 
     class TestPydanticObjects:
         @pytest.mark.xfail
         def test_mocking_nested_attributes(self) -> None:
-            mega_mock = MegaMock.it(Parent)
+            mega_mock = MegaMock.this(Parent)
             mega_mock.child.attribute = "foo"
 
         def test_split_out_attributes(self) -> None:
-            mega_mock = MegaMock.it(Parent)
-            mega_mock.child = MegaMock.it(Child)
+            mega_mock = MegaMock.this(Parent)
+            mega_mock.child = MegaMock.this(Child)
             mega_mock.child.attribute = "foo"


### PR DESCRIPTION
Addresses #100

This adds `MegaMock.this(...)` and changes `MegaMock.it(...)` for class instances.

`MegaMock.this` is basically the old logic for `MegaMock.it`. I wobbled a bit with naming this. The top reason to create to use `MegaMock.it` is to create a mock class instance, not mock a function, method, or class. This preserves using `.it` as the primary means of creating a mock or patching.