### PR TITLE
Add fix for subscripted generics error when doing assignment

### DIFF
--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -421,6 +421,8 @@ class _MegaMockMixin(Generic[T, U]):
                 is_allowed_type = isinstance(value, allowed_values)
             except TypeError:
                 origin = get_origin(allowed_values)
+                if not origin:
+                    raise
                 if not isinstance(value, origin):
                     raise_type_error()
             else:

--- a/megamock/megamocks.py
+++ b/megamock/megamocks.py
@@ -17,6 +17,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    get_origin,
     get_type_hints,
     overload,
 )
@@ -414,8 +415,17 @@ class _MegaMockMixin(Generic[T, U]):
             def raise_type_error() -> None:
                 raise TypeError(f"{value!r} is not an instance of {allowed_values}")
 
-            if not isinstance(value, allowed_values):
-                raise_type_error()
+            # This is pretty basic but should handle most cases
+            # Perhaps in the future this could handle things perfectly
+            try:
+                is_allowed_type = isinstance(value, allowed_values)
+            except TypeError:
+                origin = get_origin(allowed_values)
+                if not isinstance(value, origin):
+                    raise_type_error()
+            else:
+                if not is_allowed_type:
+                    raise_type_error()
 
     def _get_spec_from_parents(
         self, _parent_stack: list[_MegaMockMixin] | None = None

--- a/tests/unit/simple_app/generics.py
+++ b/tests/unit/simple_app/generics.py
@@ -1,0 +1,7 @@
+from typing import Callable, Collection, Iterable
+
+
+class UsesGenerics:
+    my_func: Callable[[int], str]
+    my_thing: Collection[str]
+    my_iter: Iterable[Collection[str]]

--- a/tests/unit/test_megamocks.py
+++ b/tests/unit/test_megamocks.py
@@ -19,6 +19,7 @@ from tests.simple_app.pydantic_objects import Child, Parent
 from tests.unit.conftest import SomeClass
 from tests.unit.simple_app.bar import Bar
 from tests.unit.simple_app.foo import Foo
+from tests.unit.simple_app.generics import UsesGenerics
 from tests.unit.simple_app.nested_classes import NestedParent
 
 
@@ -645,3 +646,32 @@ class TestMegaMock:
             mega_mock = MegaMock.this(Parent)
             mega_mock.child = MegaMock.this(Child)
             mega_mock.child.attribute = "foo"
+
+    class TestSubscriptedGenerics:
+        def test_assigning_to_subscripted_generic_function(self) -> None:
+            mock = MegaMock.it(UsesGenerics)
+            mock.my_func = lambda x: str(x)
+
+            assert mock.my_func(5) == "5"
+
+        def test_assigning_to_subscripted_generic_collection(self) -> None:
+            mock = MegaMock.it(UsesGenerics)
+            mock.my_thing = ["foo", "bar"]
+
+            assert mock.my_thing == ["foo", "bar"]
+
+        def test_assigning_nested_generic(self) -> None:
+            mock = MegaMock.it(UsesGenerics)
+            mock.my_iter = [["foo", "bar"]]
+
+            for item in mock.my_iter:
+                assert item == ["foo", "bar"]
+
+        def test_wrong_assignment(self) -> None:
+            mock = MegaMock.it(UsesGenerics)
+
+            with pytest.raises(TypeError):
+                mock.my_func = 5
+
+            with pytest.raises(TypeError):
+                mock.my_thing = lambda x: str(x)

--- a/tests/unit/test_megamocks.py
+++ b/tests/unit/test_megamocks.py
@@ -675,3 +675,13 @@ class TestMegaMock:
 
             with pytest.raises(TypeError):
                 mock.my_thing = lambda x: str(x)
+
+        @pytest.mark.xfail
+        def test_wrong_function_argument_type(self) -> None:
+            mock = MegaMock.it(UsesGenerics)
+
+            def single_arg_wrong_type(s: str):
+                return 25
+
+            with pytest.raises(TypeError):
+                mock.my_func = single_arg_wrong_type


### PR DESCRIPTION
Addresses #97 

As per the wrong argument type x-fail test, this only does rudimentary checking