### PR TITLE
Add pyright and `MegaMock.the_class`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "MegaMock",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+	"image": "mcr.microsoft.com/devcontainers/python:3.12",
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Lint with mypy
       run: |
         poetry run mypy .
+    - name: Lint with pyright
+      run: |
+        poetry run pyright
     - name: Test with pytest
       run: |
         poetry run pytest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,6 @@
         "editor.codeActionsOnSave": {
             "source.organizeImports.ruff": true
         }
-    }
+    },
+    "python.analysis.typeCheckingMode": "basic"
 }

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,7 +9,7 @@ foo.some_method(wrong, args)  # raises error
 ```
 
 ```python
-FooMock = MegaMock.that(Foo)  # FooMock is a type
+FooMock = MegaMock.the_class(Foo)  # FooMock is a type
 ```
 
 ## Patch objects by simply passing them in. Patches start automatically

--- a/GUIDANCE.md
+++ b/GUIDANCE.md
@@ -265,8 +265,9 @@ def test_that(self) -> None:
 ```
 
 Use `megainstance` to go from a mock class to the mock instance. This is typically used by `MegaPatch`.
-`MegaMock` will automatically create a mock instance of a passed in class, but you can change
-this behavior by setting `instance=False` when creating the mock.
+`MegaMock.it(...)` will automatically create a mock instance of a passed in class. To create a mock class instead,
+use `my_class_mock = MegaMock.the_class(...)`. To access the instance returned, use `MegaMock(my_class_mock).megainstance`.
+Due to limitations in the Python type system, the "cast" using `MegaMock` is probably needed if you are using type checks.
 
 This library was written with a leaning towards `pytest`, which is a popular testing library. See [usage](README.md#usage-pytest) in
 the readme for more information about using the pytest plugin that comes with the library.

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,4 @@
 check_all:
 	poetry run ruff megamock tests
 	poetry run mypy .
+	poetry run pyright

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ function prior to importing any production or test code. You will also want it s
 
 **Core Classes**
 
-`MegaMock` - the primary class for a mocked object. This is similar to `MagicMock`. To create a mock instance of a class, use `MegaMock.it(MyClass)` to make `MyClass` the [spec](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.create_autospec). To create mock instances of instantiated objects, functions, classes (the type), etc, use `MegaMock.this(some_object)`.
+`MegaMock` - the primary class for a mocked object. This is similar to `MagicMock`. To create a mock instance of a class, use `MegaMock.it(MyClass)` to make `MyClass` the [spec](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.create_autospec). To create a mock class (the type) use `MegaMock.the_class(MyClass)`. To create mock instances of instantiated objects, functions, etc, use `MegaMock.this(some_object)`.
 
 `MegaPatch` - the class for patching. This is similar to `patch`. Use `MegaPath.it(MyObject)` to replace new instances of the `MyObject` class.
 
@@ -170,7 +170,7 @@ def test_something(...):
 ```
 
 `MegaMock` objects have the same attributes as regular `MagicMock`s plus `megamock` and `megainstance`.
-For example, `my_mega_mock.megamock.spy` is the object being spied, if set. `my_class_mock.megainstance` is the instance returned when the class is instantiated.
+For example, `my_mega_mock.megamock.spy` is the object being spied, if set. `my_class_mock.megainstance` is the instance returned when the class is instantiated. Note that you typically access the megainstance with `MegaMock(my_class_mock).megainstance` due to limitations in the type system.
 
 The [guidance document](GUIDANCE.md) is available to provide in-depth information on using mocking and MegaMock. Continuing reading to
 quickly jump in to examples.
@@ -195,7 +195,7 @@ mock_instance = MegaMock.it(MyClass)
 Creating a mock class itself:
 
 ```python
-mock_class = MegaMock.this(MyClass)
+mock_class = MegaMock.the_class(MyClass)
 func_that_wants_a_type(mock_class)
 ```
 

--- a/megamock/__init__.py
+++ b/megamock/__init__.py
@@ -10,5 +10,4 @@ __all__ = [
     "MegaMock",
     "MegaPatch",
     "start_import_mod",
-    "UseRealLogic",
 ]

--- a/megamock/import_machinery.py
+++ b/megamock/import_machinery.py
@@ -139,6 +139,11 @@ def start_import_mod() -> None:
     """
 
     def new_import(*args, **kwargs) -> ModuleType:
+        target_module: ModuleType | None = None
+        calling_module: ModuleType | None = None
+        frame: FrameType | None = None
+        names: tuple[str] | None = None
+
         perf_stats["num_imports"] += 1
         measure_start()
         result = orig_import(*args, **kwargs)
@@ -167,8 +172,10 @@ def start_import_mod() -> None:
             measure("total_get_frame")
             assert calling_module
             measure_start()
+            assert frame
             full_line = _reconstruct_full_line(frame)
             measure("total_reconstruct")
+            assert names
             for k in names:
                 measure_start()
                 if full_line and (

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -61,7 +61,7 @@ class MegaPatch(Generic[T, U]):
         patches: list[mock._patch],
         new_value: MegaMock | Any,
         return_value: Any,
-        mocker: ModuleType | object
+        mocker: ModuleType | object,
         # _merged_type: type[U] | None = None,
     ) -> None:
         self._patches = patches
@@ -103,7 +103,7 @@ class MegaPatch(Generic[T, U]):
         return cast(MegaMock[T, U], self._return_value)
 
     @return_value.setter
-    def return_value(self, new_value: MegaMock[T, U]) -> None:
+    def return_value(self, new_value: MegaMock[T, U] | Any) -> None:
         self._return_value = new_value
         self._new_value.return_value = new_value
 
@@ -158,7 +158,7 @@ class MegaPatch(Generic[T, U]):
     def stop(self) -> None:
         # support for pytest-mock and similar
         if hasattr(self._mocker, "stopall"):
-            self._mocker.stopall()
+            self._mocker.stopall()  # type: ignore
         else:
             # built-in mock
             for patch in self._patches:
@@ -210,13 +210,13 @@ class MegaPatch(Generic[T, U]):
             if inspect.isfunction(autospeced):
                 assert hasattr(autospeced, "return_value")
                 if return_value is not _MISSING:
-                    autospeced.return_value = return_value
+                    autospeced.return_value = return_value  # type: ignore
                 if side_effect is not None:
                     autospeced.side_effect = side_effect  # type: ignore
                 new = autospeced
             else:
                 new = MegaMock.from_legacy_mock(autospeced, spec=thing)
-            return_value = new.return_value
+            return_value = new.return_value  # type: ignore
         else:
             if return_value is _MISSING:
                 return_value = MegaMock()
@@ -256,7 +256,7 @@ class MegaPatch(Generic[T, U]):
                 mocker, "patch"
             ), "mocker does not appear to be a Mocker object"
 
-        if autostart is False and not hasattr(mocker.patch, "start"):
+        if autostart is False and not hasattr(mocker.patch, "start"):  # type: ignore
             logger.warning(
                 "Disabling autostart doesn't appear to be supported by mocker. "
                 "Falling back to built in mock"
@@ -362,7 +362,7 @@ class MegaPatch(Generic[T, U]):
                     return_value = MegaMock()
                 else:
                     return_value = provided_return_value
-                new = MegaMock[None, None](return_value=return_value)
+                new = MegaMock[None, None](return_value=return_value)  # type: ignore
         else:
             new = new_given
             if provided_return_value is not _MISSING:

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,6 +126,20 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.8.0"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+files = [
+    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "23.2"
 description = "Core utilities for Python packages"
@@ -215,6 +229,24 @@ dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
 
 [[package]]
+name = "pyright"
+version = "1.1.337"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyright-1.1.337-py3-none-any.whl", hash = "sha256:8cbd4ef71797258f816a8393a758c9c91213479f472082d0e3a735ef7ab5f65a"},
+    {file = "pyright-1.1.337.tar.gz", hash = "sha256:81d81f839d1750385390c4c4a7b84b062ece2f9a078f87055d4d2a5914ef2a08"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "pytest"
 version = "7.4.3"
 description = "pytest: simple powerful testing with Python"
@@ -281,6 +313,22 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "69.0.2"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "setuptools-69.0.2-py3-none-any.whl", hash = "sha256:1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2"},
+    {file = "setuptools-69.0.2.tar.gz", hash = "sha256:735896e78a4742605974de002ac60562d286fa8051a7e2299445e8e8fbb01aa6"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -333,4 +381,4 @@ all = ["asttokens (>=2.0.0,<3.0.0)", "pure_eval (<1.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10 <4.0"
-content-hash = "81ce9479836fb8755df3a3b9e6306228045d06447fa9d57a2ed817cdaa56e3b2"
+content-hash = "7e9a842f442b918ddef5633d7dcef6c1b0255bf6ec1805ee26a6c29cfb10c9da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 python = ">=3.10 <4.0"
 varname = { extras = ["asttokens"], version = "~0.10.0" }
 asttokens = "~2.2.1"
+pyright = "^1.1.337"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"

--- a/tests/perf/test_importer.py
+++ b/tests/perf/test_importer.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     start_time = time.time()
 
-    import generated_modules.import_generated_modules as import_generated_modules
+    import generated_modules.import_generated_modules as import_generated_modules  # type: ignore # noqa
 
     end_time = time.time()
 

--- a/tests/unit/simple_app/does_rename.py
+++ b/tests/unit/simple_app/does_rename.py
@@ -1,9 +1,8 @@
-from .foo import (
-    Foo as MyFoo
-)
+from .foo import Foo as MyFoo
 
 foo_instance = MyFoo("something")
 
 
 def func_that_uses_foo() -> str:
+    foo_instance = MyFoo("something else")
     return foo_instance.some_method()

--- a/tests/unit/test_import_machinery.py
+++ b/tests/unit/test_import_machinery.py
@@ -27,7 +27,7 @@ class TestReconstructFullLine:
 
     def test_multiline_parenthesis_code(self) -> None:
         self._code_lines_patch.mock.return_value = ["from foo import (\n"], 2
-        self._mock_frame.f_code.co_filename = "a_file.py"
+        self._mock_frame.f_code.co_filename = "a_file.py"  # type: ignore
         getline = MegaMock.this(
             linecache.getline, side_effect=["    bar,\n", "    baz,\n", ")\n"]
         )
@@ -39,7 +39,7 @@ class TestReconstructFullLine:
 
     def test_multiline_backslash_code(self) -> None:
         self._code_lines_patch.mock.return_value = ["from foo import \\\r\n"], 2
-        self._mock_frame.f_code.co_filename = "a_file.py"
+        self._mock_frame.f_code.co_filename = "a_file.py"  # type: ignore
         getline = MegaMock.this(
             linecache.getline,
             side_effect=["    bar,\\\r\n", "    baz\r\n", "dont be here\r\n"],

--- a/tests/unit/test_megapatches.py
+++ b/tests/unit/test_megapatches.py
@@ -12,23 +12,22 @@ from tests.unit.simple_app.async_portion import (
     SomeClassWithAsyncMethods,
     an_async_function,
 )
-from tests.unit.simple_app.bar import Bar, some_context_manager
-from tests.unit.simple_app.bar import some_func
+from tests.unit.simple_app.bar import Bar, some_context_manager, some_func
 from tests.unit.simple_app.bar import some_func as some_other_func
 from tests.unit.simple_app.does_rename import func_that_uses_foo as func_uses_foo
-from tests.unit.simple_app.foo import Foo
+from tests.unit.simple_app.foo import Foo, bar, foo_instance
 from tests.unit.simple_app.foo import Foo as OtherFoo
-from tests.unit.simple_app.foo import bar
 from tests.unit.simple_app.foo import bar as other_bar_constant
-from tests.unit.simple_app.foo import foo_instance
 from tests.unit.simple_app.helpful_manager import HelpfulManager
 from tests.unit.simple_app.locks import SomeLock
 from tests.unit.simple_app.nested_classes import NestedParent
-from tests.unit.simple_app.uses_nested_classes import get_nested_class_attribute_value
+from tests.unit.simple_app.uses_nested_classes import (
+    get_nested_class_attribute_value,
+    get_nested_class_function_value,
+)
 from tests.unit.simple_app.uses_nested_classes import (
     get_nested_class_attribute_value as another_nested_class_attr,
 )
-from tests.unit.simple_app.uses_nested_classes import get_nested_class_function_value
 
 
 class TestMegaPatchPatching:
@@ -141,19 +140,21 @@ class TestMegaPatchPatching:
         assert other_bar_constant == "new_val"
         assert foo.bar == "new_val"
 
+    @pytest.mark.xfail
     def test_patch_that_is_renamed_in_non_test_module_1(self) -> None:
         patch = MegaPatch.it(Foo)
         patch.megainstance.some_method.return_value = "it worked"
 
-        func_uses_foo() == "it worked"
+        assert func_uses_foo() == "it worked"
 
+    @pytest.mark.xfail
     def test_patch_that_is_renamed_in_non_test_module_2(self) -> None:
         from tests.unit.simple_app.does_rename import MyFoo
 
         patch = MegaPatch.it(MyFoo)
         patch.megainstance.some_method.return_value = "it worked"
 
-        func_uses_foo() == "it worked"
+        assert func_uses_foo() == "it worked"
 
     def test_renamed_multiline(self) -> None:
         patch = MegaPatch.it(get_nested_class_attribute_value)
@@ -321,7 +322,6 @@ class TestMegaPatchReturnValue:
 
 
 class TestMegaPatchObject:
-
     # Issue https://github.com/JamesHutchison/megamock/issues/8
     @pytest.mark.xfail
     def test_patching_local_object(self) -> None:
@@ -347,7 +347,7 @@ class TestAsyncPatching:
     async def test_patching_async_method(self) -> None:
         MegaPatch.it(SomeClassWithAsyncMethods.some_method, return_value="val")
 
-        assert await (SomeClassWithAsyncMethods().some_method("s")) == "val"
+        assert await SomeClassWithAsyncMethods().some_method("s") == "val"
 
 
 class TestGotchaCheck:


### PR DESCRIPTION
- Add pyright
- Fix megainstance type hint
- Add `MegaMock.the_class`
- Fix rename tests and mark as xfail

`MegaMock.that` was returning the type object for `megainstance`.

This project would really benefit from Python adding intersection types. A substantial amount of time was spent trying to make the type hinters happy and also return types the IDE knew how to autocomplete.