### PR TITLE
#84 Add MegaPatchContext and support session patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,7 @@ pytest -p megamock.plugins.pytest
 addopts = "-p megamock.plugins.pytest"
 ```
 
-The pytest plugin also automatically stops `MegaPatch`es after each test. To disable this behavior, pass in the `--do_not_autostop_megapatches`
-command line argument. If `pytest-mock` is installed, the default mocker will be switched to the `pytest-mock` `mocker`.
+The pytest plugin also automatically stops `MegaPatch`es after each test. If `pytest-mock` is installed, the default mocker will be switched to the `pytest-mock` `mocker`.
 
 ### Usage (other test frameworks)
 

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from functools import cached_property
 from types import ModuleType
-from typing import Any, Callable, Generic, Iterable, TypeVar, cast
+from typing import Any, Callable, Generic, Iterable, Self, TypeVar, cast
 from unittest import mock
 
 from varname import argname  # type: ignore
@@ -48,9 +48,44 @@ class MegaPatchBehavior:
         return MegaPatchBehavior(autospec=True)
 
 
+class MegaPatchContext:
+    _active_patches: set[MegaPatch]
+
+    def __init__(self) -> None:
+        self._active_patches = set()
+
+    def active_patches(self) -> list[MegaPatch]:
+        return list(self._active_patches)
+
+    def add(self, megapatch: MegaPatch) -> None:
+        self._active_patches.add(megapatch)
+
+    def remove(self, megapatch: MegaPatch) -> None:
+        self._active_patches.remove(megapatch)
+
+    def stop_all(self) -> None:
+        for megapatch in self.active_patches():
+            megapatch.stop()
+
+    def __del__(self) -> None:
+        try:
+            self.stop_all()
+        except Exception:
+            pass
+
+    def __enter__(self) -> Self:
+        MegaPatch.context_stack.append(self)
+        return self
+
+    def __exit__(self, *args, **kwargs) -> None:
+        self.stop_all()
+        top_of_stack = MegaPatch.context_stack.pop()
+        assert top_of_stack is self
+
+
 class MegaPatch(Generic[T, U]):
-    __reserved_names = {"_patches", "_thing", "_path", "_mocked_value", "_return_value"}
-    _active_patches: set[MegaPatch] = set()
+    root_context = MegaPatchContext()
+    context_stack = [root_context]
 
     default_mocker: ModuleType | object = mock
 
@@ -62,13 +97,14 @@ class MegaPatch(Generic[T, U]):
         new_value: MegaMock | Any,
         return_value: Any,
         mocker: ModuleType | object,
-        # _merged_type: type[U] | None = None,
+        context: MegaPatchContext | None = None,
     ) -> None:
         self._patches = patches
         self._thing: Any | None = thing
         self._new_value: MegaMock = new_value
         self._return_value = return_value
         self._mocker = mocker
+        self._context = context or MegaPatch.context_stack[-1]
 
         self._started = False
 
@@ -152,7 +188,8 @@ class MegaPatch(Generic[T, U]):
             # built-in mock
             for patch in self._patches:
                 patch.start()
-        MegaPatch._active_patches.add(self)
+        self._context.add(self)
+        MegaPatch.root_context.add(self)
         self._started = True
 
     def stop(self) -> None:
@@ -163,7 +200,8 @@ class MegaPatch(Generic[T, U]):
             # built-in mock
             for patch in self._patches:
                 patch.stop()
-        MegaPatch._active_patches.remove(self)
+        self._context.remove(self)
+        MegaPatch.root_context.remove(self)
         self._started = False
 
     def __enter__(self) -> MegaPatch[T, U]:
@@ -189,12 +227,18 @@ class MegaPatch(Generic[T, U]):
         return wrapper
 
     @staticmethod
-    def active_patches() -> list[MegaPatch]:
-        return list(MegaPatch._active_patches)
+    def new_context() -> MegaPatchContext:
+        context = MegaPatchContext()
+        MegaPatch.context_stack.append(context)
+        return context
 
     @staticmethod
-    def stop_all() -> None:
-        for megapatch in list(MegaPatch._active_patches):
+    def active_patches(context: MegaPatchContext | None = None) -> list[MegaPatch]:
+        return (context or MegaPatch.root_context).active_patches()
+
+    @staticmethod
+    def stop_all(context: MegaPatchContext | None = None) -> None:
+        for megapatch in list((context or MegaPatch).active_patches()):
             megapatch.stop()
 
     @staticmethod

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from functools import cached_property
 from types import ModuleType
-from typing import Any, Callable, Generic, Iterable, Self, TypeVar, cast
+from typing import Any, Callable, Generic, Iterable, TypeVar, cast
 from unittest import mock
 
 from varname import argname  # type: ignore
@@ -73,7 +73,7 @@ class MegaPatchContext:
         except Exception:
             pass
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> MegaPatchContext:
         MegaPatch.context_stack.append(self)
         return self
 

--- a/megamock/plugins/pytest.py
+++ b/megamock/plugins/pytest.py
@@ -1,4 +1,5 @@
-from typing import Any
+from typing import Iterable
+
 import pytest
 
 from megamock.megapatches import MegaPatch
@@ -10,19 +11,10 @@ def pytest_load_initial_conftests(*args, **kwargs) -> None:
     megamock.start_import_mod()
 
 
-def pytest_addoption(parser: Any) -> None:
-    parser.addoption(
-        "--do_not_autostop_megapatches",
-        help="Disable autostopping MegaPatches after every test",
-        action="store",
-        default=False,
-    )
-
-
 @pytest.fixture(autouse=True)
-def stop_all_megapatches(request) -> None:
-    if not request.config.getoption("--do_not_autostop_megapatches"):
-        MegaPatch.stop_all()
+def megapatch_contexts() -> Iterable:
+    with MegaPatch.new_context():
+        yield
 
 
 # swap out default mocker if pytest-mock is installed

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,8 @@
 import pytest
-from megamock.megapatches import MegaPatch
 
+from megamock.megapatches import MegaPatch
 from tests.unit.simple_app.for_autouse_1 import modified_function
+from tests.unit.simple_app.for_autouse_2 import session_modified_function
 
 
 class SomeClass:
@@ -19,3 +20,8 @@ class SomeClass:
 @pytest.fixture(autouse=True)
 def some_autouse_fixture() -> None:
     MegaPatch.it(modified_function, return_value="modified")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def some_session_autouse_fixture() -> None:
+    MegaPatch.it(session_modified_function, return_value="session_modified")

--- a/tests/unit/simple_app/for_autouse_2.py
+++ b/tests/unit/simple_app/for_autouse_2.py
@@ -1,2 +1,6 @@
 def modified_function() -> str:
     return "original"
+
+
+def session_modified_function() -> str:
+    return "original"

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -1,6 +1,10 @@
 from tests.unit.simple_app.for_autouse_1 import get_value
+from tests.unit.simple_app.for_autouse_2 import session_modified_function
 
 
 class TestPytestPlugin:
     def test_import_invoked_early_enough(self) -> None:
         assert get_value() == "modified"
+
+    def test_session_modified_fixture(self) -> None:
+        assert session_modified_function() == "session_modified"


### PR DESCRIPTION
Addresses #84 

Decided against giving patches their own scopes and instead its using a stack. It's simpler this way and I can't think of a good use case for having patches floating around and leaving them on other than maybe top-level patches for things like external dependencies.