### PR TITLE
#80 Correct get_reverse_references and add check whether single patch should be done

### DIFF
--- a/megamock/import_references.py
+++ b/megamock/import_references.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 from types import ModuleType
-from typing import NamedTuple
 
-ModAndName = NamedTuple("ModAndName", [("module", str), ("name", str)])
+from megamock.import_types import ModAndName
 
 
 class References:
@@ -97,7 +96,7 @@ class References:
         And then the MegaPatch might look like this:
             MegaPatch.it(OtherFoo.bar, ...)
         """
-        components = original_name.split(".", 0)
+        components = original_name.split(".")
         if len(components) > 1:
             base_name, right_side = components[0], [".".join(components[1:])]
         else:

--- a/megamock/import_types.py
+++ b/megamock/import_types.py
@@ -1,0 +1,3 @@
+from typing import NamedTuple
+
+ModAndName = NamedTuple("ModAndName", [("module", str), ("name", str)])

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -12,6 +12,7 @@ from unittest import mock
 from varname import argname  # type: ignore
 
 from megamock.import_references import References
+from megamock.import_types import ModAndName
 from megamock.megamocks import MegaMock, _MegaMockMixin, _UseRealLogic
 
 logger = logging.getLogger(__name__)
@@ -455,14 +456,20 @@ class MegaPatch(Generic[T, U]):
         kwargs: dict,
     ) -> list[mock._patch]:  # type: ignore  # mypy bug?
         patches = []
-        for path, named_as in (
+        paths_and_names = (
             References.get_references(module_path, corrected_passed_in_name)
             | References.get_reverse_references(module_path, corrected_passed_in_name)
-            | {(module_path, name_to_patch)}
-        ):
+            | {ModAndName(module_path, name_to_patch)}
+        )
+        do_one_patch = "." in corrected_passed_in_name
+        # if the passed in name is a nested name, then only patch ones. References
+        # to it will already
+        for path, named_as in paths_and_names:
             mock_path = f"{path}.{named_as}"
             p = mocker.patch(mock_path, new, **kwargs)
             patches.append(p)
+            if do_one_patch:
+                break
 
         return patches
 

--- a/tests/unit/test_megapatches.py
+++ b/tests/unit/test_megapatches.py
@@ -89,6 +89,12 @@ class TestMegaPatchPatching:
 
         assert Foo("").z == "b"
 
+    def test_patch_from_module_reference(self) -> None:
+        patch = MegaPatch.it(foo.Foo)
+        patch.return_value.z = "b"
+
+        assert Foo("").z == "b"
+
     def test_patch_global_module_variable(self) -> None:
         MegaPatch.it(bar, new="a")
 
@@ -101,6 +107,10 @@ class TestMegaPatchPatching:
 
     def test_patch_class_method_supports_return_value_as_arg(self) -> None:
         MegaPatch.it(Foo.some_method, return_value="foo")
+        assert Foo("s").some_method() == "foo"
+
+    def test_patch_class_method_from_module_reference(self) -> None:
+        MegaPatch.it(foo.Foo.some_method, return_value="foo")
         assert Foo("s").some_method() == "foo"
 
     def test_patch_class_method_supports_return_value_as_attribute(self) -> None:


### PR DESCRIPTION
Addresses #80 

This fixes a bug in the logic for `get_reverse_references` which resulted in it not returning any of the reverse references. However, this bug only occurred when you had a nested reference like `Foo.bar`, so there wasn't a reason to look up the references anyways. This updates `_build_patches` so that if there's a nested patch, it doesn't bother fetching references.