### PR TITLE
#110 Fix import when imported module is not yet in sys.modules

### DIFF
--- a/megamock/import_machinery.py
+++ b/megamock/import_machinery.py
@@ -146,15 +146,15 @@ def start_import_mod() -> None:
 
         perf_stats["num_imports"] += 1
         measure_start()
-        result = orig_import(*args, **kwargs)
+        imported_module = orig_import(*args, **kwargs)
         measure("total_orig_import")
 
         measure_start()
         module_name = args[0]
         proceed = (
             module_name not in skip_modules
-            and not module_name.startswith("_")
-            and (target_module := sys.modules.get(module_name))
+            and not module_name.startswith("_")  # skip private or C modules
+            and (target_module := imported_module or sys.modules.get(module_name))
             and len(args) > 3
             and (names := args[3])
         )
@@ -196,6 +196,6 @@ def start_import_mod() -> None:
                 References.add_reference(target_module, calling_module, k, renamed_to)
                 measure("total_add_reference")
 
-        return result
+        return imported_module
 
     builtins.__import__ = new_import

--- a/tests/unit/test_megapatches.py
+++ b/tests/unit/test_megapatches.py
@@ -191,14 +191,12 @@ class TestMegaPatchPatching:
         assert other_bar_constant == "new_val"
         assert foo.bar == "new_val"
 
-    @pytest.mark.xfail
     def test_patch_that_is_renamed_in_non_test_module_1(self) -> None:
         patch = MegaPatch.it(Foo)
         patch.megainstance.some_method.return_value = "it worked"
 
         assert func_uses_foo() == "it worked"
 
-    @pytest.mark.xfail
     def test_patch_that_is_renamed_in_non_test_module_2(self) -> None:
         from tests.unit.simple_app.does_rename import MyFoo
 


### PR DESCRIPTION
Addresses #110 

Looks like this issue had nothing to do with the import structure and rather it was related to the imported module not being in `sys.modules` yet.