### PR TITLE
Add support for directly giving a property a side-effect

### DIFF
--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -278,6 +278,7 @@ class MegaPatch(Generic[T, U]):
         autostart: bool = True,
         mocker: ModuleType | object | None = None,
         new_callable: Callable | None = None,
+        side_effect: Any | None = None,
         **kwargs: Any,
     ):
         """
@@ -293,6 +294,7 @@ class MegaPatch(Generic[T, U]):
             object to return. This is usually some replacement Mock bject.
             This is mainly for legacy support and is not recommended since it can't be
             combined with autospec.
+        :param side_effect: The side-effect to use
         """
         if mocker is None:
             mocker = MegaPatch.default_mocker
@@ -315,6 +317,8 @@ class MegaPatch(Generic[T, U]):
         else:
             parent_mock = None
 
+        kwargs["side_effect"] = side_effect  # this may get popped later
+
         if behavior is None:
             behavior = MegaPatchBehavior.for_thing(thing)
         if new_callable is not None:
@@ -323,6 +327,15 @@ class MegaPatch(Generic[T, U]):
             return_value = kwargs.get("return_value")
             kwargs["new_callable"] = new_callable
         else:
+            # support giving properties side-effects
+            if (
+                isinstance(thing, (property, cached_property))
+                and side_effect
+                and not new
+            ):
+                new = property(MegaMock(side_effect=side_effect))
+                kwargs.pop("side_effect")
+
             if (autospec := kwargs.pop("autospec", None)) in (True, False):
                 behavior.autospec = autospec
             new, return_value = MegaPatch._new_return_value(

--- a/tests/unit/test_megapatches.py
+++ b/tests/unit/test_megapatches.py
@@ -234,12 +234,15 @@ class TestMegaPatchPatching:
 
         assert str(exc.value) == "Error!"
 
-    @pytest.mark.xfail
     def test_setting_side_effect_to_a_property(self) -> None:
-        # This doesn't work because side_effect requires making a call.
-        # If you really need to have a property that raises an exception,
-        # then you'll need to structure your code to call a function
-        # and then mock that function.
+        MegaPatch.it(Foo.zzz, side_effect=Exception("Error!"))
+
+        with pytest.raises(Exception) as exc:
+            Foo("s").zzz
+
+        assert str(exc.value) == "Error!"
+
+    def test_setting_side_effect_to_a_cached_property(self) -> None:
         MegaPatch.it(Foo.helpful_manager, side_effect=Exception("Error!"))
 
         with pytest.raises(Exception) as exc:


### PR DESCRIPTION
Also splits up tests so it tests both `property` and `cached_property` since they aren't quite the same.