### PR TITLE
Fix session context not ending

### DIFF
--- a/megamock/plugins/pytest.py
+++ b/megamock/plugins/pytest.py
@@ -17,6 +17,12 @@ def megapatch_contexts() -> Iterable:
         yield
 
 
+@pytest.fixture(scope="session", autouse=True)
+def megapatch_session_contexts() -> Iterable:
+    with MegaPatch.new_context():
+        yield
+
+
 # swap out default mocker if pytest-mock is installed
 try:
     from pytest_mock import MockerFixture  # type: ignore  # noqa  # test for install


### PR DESCRIPTION
When using the pytest hot reloader, determined that session context patches weren't being cleaned up. Solution was to give them their own context