### PR TITLE
Reduce argname to fallback instead of primary, fix lingering contexts

### DIFF
--- a/tests/unit/test_megapatches.py
+++ b/tests/unit/test_megapatches.py
@@ -32,7 +32,6 @@ from tests.unit.simple_app.uses_nested_classes import (
 
 class TestMegaPatchContext:
     def test_active_patches(self) -> None:
-        "foosssss"
         megapatch_context = MegaPatchContext()
         megapatch = MegaMock.it(MegaPatch)
         megapatch_context.add(megapatch)
@@ -73,23 +72,18 @@ class TestMegaPatchContext:
 
 
 class TestMegaPatchPatching:
-    "Eerrreeeteees"
-
     def test_patch_class_itself(self) -> None:
-        "feeeeeeeeee"
         patch = MegaPatch.it(Foo)
         patch.new_value.z = "a"
 
         assert Foo.z == "a"
         Foo("s")  # should work
-        # something
+
         # sanity check, instance should NOT work because it doesn't support calling
         with pytest.raises(TypeError):
             Foo("s")()  # type: ignore
 
     def test_patch_class_instance_from_type(self) -> None:
-        "ssssstteeeets"
-        "eeeeeffeeeeeeerrr"
         patch = MegaPatch.it(Foo)
         patch.return_value.z = "b"
 
@@ -112,11 +106,7 @@ class TestMegaPatchPatching:
         assert Foo.moo == "dog"
 
     def test_patch_class_method_supports_return_value_as_arg(self) -> None:
-        "fooffff"
-        "barsss"
-        "moo"
         MegaPatch.it(Foo.some_method, return_value="foo")
-
         assert Foo("s").some_method() == "foo"
 
     def test_patch_class_method_from_module_reference(self) -> None:

--- a/tests/unit/test_megapatches.py
+++ b/tests/unit/test_megapatches.py
@@ -32,6 +32,7 @@ from tests.unit.simple_app.uses_nested_classes import (
 
 class TestMegaPatchContext:
     def test_active_patches(self) -> None:
+        "foosssss"
         megapatch_context = MegaPatchContext()
         megapatch = MegaMock.it(MegaPatch)
         megapatch_context.add(megapatch)
@@ -72,18 +73,23 @@ class TestMegaPatchContext:
 
 
 class TestMegaPatchPatching:
+    "Eerrreeeteees"
+
     def test_patch_class_itself(self) -> None:
+        "feeeeeeeeee"
         patch = MegaPatch.it(Foo)
         patch.new_value.z = "a"
 
         assert Foo.z == "a"
         Foo("s")  # should work
-
+        # something
         # sanity check, instance should NOT work because it doesn't support calling
         with pytest.raises(TypeError):
             Foo("s")()  # type: ignore
 
     def test_patch_class_instance_from_type(self) -> None:
+        "ssssstteeeets"
+        "eeeeeffeeeeeeerrr"
         patch = MegaPatch.it(Foo)
         patch.return_value.z = "b"
 
@@ -106,7 +112,11 @@ class TestMegaPatchPatching:
         assert Foo.moo == "dog"
 
     def test_patch_class_method_supports_return_value_as_arg(self) -> None:
+        "fooffff"
+        "barsss"
+        "moo"
         MegaPatch.it(Foo.some_method, return_value="foo")
+
         assert Foo("s").some_method() == "foo"
 
     def test_patch_class_method_from_module_reference(self) -> None:
@@ -587,3 +597,10 @@ class TestMegaPatchNames:
         # that bypasses MegaMock logic and returns MagicMock
         patch = MegaPatch.it(Foo.some_method)
         assert "name='Foo.some_method'" in str(patch.return_value)
+
+
+class TestMegaPatchNewContext:
+    def test_new_context_with_context_manager(self) -> None:
+        context = MegaPatch.new_context()
+        with context:
+            assert len([x for x in MegaPatch.context_stack if x is context]) == 1


### PR DESCRIPTION
Fixes the accumulation of contexts due to `with MegaPatch.new_context():` double adding them

Makes `passed_in_name` lookup more robust by starting with the qualified name, if its available. This is more of band-aid than proper fix but it reduces inconvenience.