### PR TITLE
#125 Use `no_type_check` instead of hack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "megamock"
-version = "0.1.0-beta.9"
+version = "0.1.0-beta.10"
 description = "Mega mocking capabilities - stop using dot-notated paths!"
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"


### PR DESCRIPTION
Addresses #125

This fixes an issue where type hints were not working on JetBrains based IDEs. This also removes the hack that I've hated (I wrote it, I'm allowed to hate it). It turns out there's a decorator, `no_type_check` I was unaware of that lets you disable type checking for mypy without disrupting the IDE's interpretation of the type hints. This is a much more elegant solution and testing between pycharm and vs code I couldn't find a downside to this approach.

It's worth calling out that Pylance catches the wrong argument types being passed in while mypy just ignores everything. This, however, seems to be the current behavior.

![pylance-catching](https://github.com/JamesHutchison/megamock/assets/122519877/ef42b86a-90c1-4084-889c-40c1bea4de54)
