### PR TITLE
Fix `MegaPatch.megainstance` typing for PyCharm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,12 +7,12 @@
     "python.analysis.autoImportCompletions": true,
     "python.analysis.indexing": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.codeActionsOnSave": {
-            "source.organizeImports.ruff": true
+            "source.organizeImports.ruff": "explicit"
         }
     },
     "python.analysis.typeCheckingMode": "basic"

--- a/GUIDANCE.md
+++ b/GUIDANCE.md
@@ -168,8 +168,8 @@ There is no simple way to do this in the built-in mock library.
 With MegaMock, you can do this:
 
 ```python
-MegaPatch.it(MyClass)
-use_real_logic(MyClass.megainstance.some_func)
+patch = MegaPatch.it(MyClass)
+use_real_logic(patch.megainstance.some_func)
 
 do_test_logic(...)
 ```

--- a/megamock/megapatches.py
+++ b/megamock/megapatches.py
@@ -6,7 +6,7 @@ import logging
 import sys
 from functools import cached_property
 from types import ModuleType
-from typing import Any, Callable, Generic, Iterable, TypeVar, cast
+from typing import Any, Callable, Generic, Iterable, TypeVar, cast, no_type_check
 from unittest import mock
 
 from varname import argname  # type: ignore
@@ -270,6 +270,7 @@ class MegaPatch(Generic[T, U]):
             new = MegaMock(return_value=return_value)
         return new, return_value
 
+    @no_type_check
     @staticmethod
     def it(
         thing: T,
@@ -282,7 +283,7 @@ class MegaPatch(Generic[T, U]):
         new_callable: Callable | None = None,
         side_effect: Any | None = None,
         **kwargs: Any,
-    ):
+    ) -> MegaPatch[T, MegaMock[T, MegaMock | T] | T]:
         """
         MegaPatch something.
 
@@ -363,7 +364,7 @@ class MegaPatch(Generic[T, U]):
             mocker, module_path, name_to_patch, corrected_passed_in_name, new, kwargs
         )
 
-        mega_patch = MegaPatch[T, type[MegaMock | T]](
+        mega_patch = MegaPatch(
             thing=thing,
             patches=patches,
             new_value=new,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "megamock"
-version = "0.1.0-beta.10"
+version = "0.1.0-beta.11"
 description = "Mega mocking capabilities - stop using dot-notated paths!"
 authors = ["James Hutchison <jamesghutchison@proton.me>"]
 readme = "README.md"


### PR DESCRIPTION
Continuation of the solution used in #125 where type hinting is provided but `no_type_check` decorator is used to disable mypy complaining about union usage.

As with before, having an intersection type in Python would be a better solution.